### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Add License Header
-        run: npx @kt3k/license-checker@3.2.2
+      - name: Check License Headers
+        run: npx --yes @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -30,10 +30,9 @@
     ".gradle",
     "gradle/wrapper",
     "settings.gradle",
-    "**/build/",
+    "build/",
     "licenses/",
-    "src/test/resources/",
-    "**/test/resources/",
+    "test/resources/",
     "LICENSE",
     "NOTICE"
   ]

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,40 @@
+{
+  "**/*.*": [
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".xml",
+    ".config",
+    ".png",
+    ".jar",
+    ".pem",
+    ".jks",
+    ".bcfks",
+    ".p12",
+    ".gz",
+    ".lock",
+    ".toml",
+    ".ini",
+    ".bat",
+    ".policy",
+    ".properties",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".lycheeignore",
+    ".gradle",
+    "gradle/wrapper",
+    "settings.gradle",
+    "**/build/",
+    "licenses/",
+    "src/test/resources/",
+    "**/test/resources/",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceGroupExtension.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceGroupExtension.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.opensearch.sample;
 
 import java.util.Set;

--- a/sample-resource-plugin/src/main/resources/META-INF/services/org.opensearch.security.spi.resources.ResourceSharingExtension
+++ b/sample-resource-plugin/src/main/resources/META-INF/services/org.opensearch.security.spi.resources.ResourceSharingExtension
@@ -1,2 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
 org.opensearch.sample.SampleResourceExtension
 org.opensearch.sample.SampleResourceGroupExtension

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 

--- a/src/integrationTest/resources/META-INF/services/org.opensearch.transport.grpc.spi.GrpcInterceptorProvider
+++ b/src/integrationTest/resources/META-INF/services/org.opensearch.transport.grpc.spi.GrpcInterceptorProvider
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
 org.opensearch.security.grpc.GrpcHelpers$TestUserInjectionInterceptorProvider

--- a/src/main/java/org/opensearch/security/auth/AuthFailureListener.java
+++ b/src/main/java/org/opensearch/security/auth/AuthFailureListener.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/auth/PrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/auth/PrincipalExtractor.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/main/java/org/opensearch/security/auth/RolesInjector.java
+++ b/src/main/java/org/opensearch/security/auth/RolesInjector.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/main/java/org/opensearch/security/auth/blocking/ClientBlockRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/blocking/ClientBlockRegistry.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/auth/blocking/HeapBasedClientBlockRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/blocking/HeapBasedClientBlockRegistry.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/auth/limiting/AbstractRateLimiter.java
+++ b/src/main/java/org/opensearch/security/auth/limiting/AbstractRateLimiter.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiter.java
+++ b/src/main/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiter.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiter.java
+++ b/src/main/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiter.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/configuration/StaticResourceException.java
+++ b/src/main/java/org/opensearch/security/configuration/StaticResourceException.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/SecureSSLSettings.java
+++ b/src/main/java/org/opensearch/security/ssl/SecureSSLSettings.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/org/opensearch/security/ssl/SecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/SecurityKeyStore.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/SslExceptionHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/SslExceptionHandler.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/http/netty/ValidatingDispatcher.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/ValidatingDispatcher.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLInfoAction.java
+++ b/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLInfoAction.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/transport/DefaultPrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/DefaultPrincipalExtractor.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/transport/PrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/PrincipalExtractor.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLTransportInterceptor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLTransportInterceptor.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
+++ b/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/util/SSLCertificateHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLCertificateHelper.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/ssl/util/Utils.java
+++ b/src/main/java/org/opensearch/security/ssl/util/Utils.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/support/SecurityJsonNode.java
+++ b/src/main/java/org/opensearch/security/support/SecurityJsonNode.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2018 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/util/ratetracking/HeapBasedRateTracker.java
+++ b/src/main/java/org/opensearch/security/util/ratetracking/HeapBasedRateTracker.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/util/ratetracking/RateTracker.java
+++ b/src/main/java/org/opensearch/security/util/ratetracking/RateTracker.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/opensearch/security/util/ratetracking/SingleTryRateTracker.java
+++ b/src/main/java/org/opensearch/security/util/ratetracking/SingleTryRateTracker.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/ConfigTests.java
+++ b/src/test/java/org/opensearch/security/ConfigTests.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/ResolveAPITests.java
+++ b/src/test/java/org/opensearch/security/ResolveAPITests.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
+++ b/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/test/java/org/opensearch/security/SecurityAdminTests.java
+++ b/src/test/java/org/opensearch/security/SecurityAdminTests.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/TaskTests.java
+++ b/src/test/java/org/opensearch/security/TaskTests.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/auth/RolesInjectorTest.java
+++ b/src/test/java/org/opensearch/security/auth/RolesInjectorTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/src/test/java/org/opensearch/security/auth/blocking/HeapBasedClientBlockRegistryTest.java
+++ b/src/test/java/org/opensearch/security/auth/blocking/HeapBasedClientBlockRegistryTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiterTest.java
+++ b/src/test/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiterTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/auth/limiting/HeapBasedRateTrackerTest.java
+++ b/src/test/java/org/opensearch/security/auth/limiting/HeapBasedRateTrackerTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiterTest.java
+++ b/src/test/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiterTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2019 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
+++ b/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2015-2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/opensearch/security/ssl/TestPrincipalExtractor.java
+++ b/src/test/java/org/opensearch/security/ssl/TestPrincipalExtractor.java
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright 2017 floragunn GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/audit_config_migrater.sh
+++ b/tools/audit_config_migrater.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then

--- a/tools/hash.sh
+++ b/tools/hash.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 #install_demo_configuration.sh [-y]
 
 UNAME=$(uname -s)

--- a/tools/securityadmin.sh
+++ b/tools/securityadmin.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
