### PR TITLE
Make REST API request body max string length configurable (fixes #6434)

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -95,6 +95,7 @@ import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.util.PageCacheRecycler;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentConstraints;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
@@ -2587,6 +2588,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH,
                     ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT,
                     1,
+                    XContentConstraints.DEFAULT_MAX_STRING_LEN,
                     Property.NodeScope,
                     Property.Filtered
                 )

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2582,6 +2582,15 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     Property.Filtered
                 )
             );
+            settings.add(
+                Setting.intSetting(
+                    ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH,
+                    ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT,
+                    1,
+                    Property.NodeScope,
+                    Property.Filtered
+                )
+            );
 
             // Compliance settings moved outside the gate — see below
 

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/RequestContentValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/RequestContentValidator.java
@@ -40,6 +40,8 @@ import tools.jackson.core.JsonToken;
 import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.security.dlic.rest.api.Responses.payload;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE;
 
 public class RequestContentValidator implements ToXContent {
@@ -183,6 +185,9 @@ public class RequestContentValidator implements ToXContent {
     }
 
     protected ValidationError validationError;
+
+    /** The effective max string length that was exceeded, captured so the error response can report the configured limit. */
+    protected int maxStringLengthLimit = SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT;
 
     protected final ValidationContext validationContext;
 
@@ -403,19 +408,22 @@ public class RequestContentValidator implements ToXContent {
     }
 
     private ValidationResult<JsonNode> validateStringLength(final JsonNode jsonContent) {
-        if (exceedsMaxStringLength(jsonContent)) {
+        final int maxStringLength = validationContext.settings()
+            .getAsInt(SECURITY_RESTAPI_MAX_STRING_LENGTH, SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT);
+        if (exceedsMaxStringLength(jsonContent, maxStringLength)) {
+            this.maxStringLengthLimit = maxStringLength;
             this.validationError = ValidationError.STRING_EXCEEDS_MAX_LENGTH;
             return ValidationResult.error(RestStatus.BAD_REQUEST, this);
         }
         return ValidationResult.success(jsonContent);
     }
 
-    private boolean exceedsMaxStringLength(final JsonNode node) {
-        if (node.isTextual() && node.asText().length() > MAX_STRING_LENGTH) {
+    private boolean exceedsMaxStringLength(final JsonNode node, final int maxStringLength) {
+        if (node.isTextual() && node.asText().length() > maxStringLength) {
             return true;
         }
         for (final JsonNode child : node) {
-            if (exceedsMaxStringLength(child)) {
+            if (exceedsMaxStringLength(child, maxStringLength)) {
                 return true;
             }
         }
@@ -472,6 +480,13 @@ public class RequestContentValidator implements ToXContent {
                 for (Map.Entry<String, String> entry : wrongDataTypes.entrySet()) {
                     builder.field(entry.getKey(), entry.getValue());
                 }
+                break;
+            case STRING_EXCEEDS_MAX_LENGTH:
+                builder.field("status", "error");
+                builder.field(
+                    "reason",
+                    ValidationError.STRING_EXCEEDS_MAX_LENGTH.message() + " of " + maxStringLengthLimit + " characters"
+                );
                 break;
             default:
                 builder.field("status", "error");
@@ -541,7 +556,7 @@ public class RequestContentValidator implements ToXContent {
         PAYLOAD_MANDATORY("Request body required for this action."),
         SECURITY_NOT_INITIALIZED("Security index not initialized"),
         NULL_ARRAY_ELEMENT("`null` or blank values are not allowed as json array elements"),
-        STRING_EXCEEDS_MAX_LENGTH("String value exceeds the maximum allowed length of " + MAX_STRING_LENGTH + " characters");
+        STRING_EXCEEDS_MAX_LENGTH("String value exceeds the maximum allowed length");
 
         private final String message;
 

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -373,6 +373,10 @@ public class ConfigConstants {
     public static final String SECURITY_RESTAPI_PASSWORD_MIN_LENGTH = SECURITY_SETTINGS_PREFIX + "restapi.password_min_length";
     public static final String SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH = SECURITY_SETTINGS_PREFIX
         + "restapi.password_score_based_validation_strength";
+    // Maximum allowed length for any string value in a Security REST API request body. Guards against oversized inputs
+    // while remaining configurable, since free-form fields such as DLS/FLS queries can legitimately exceed the default.
+    public static final String SECURITY_RESTAPI_MAX_STRING_LENGTH = SECURITY_SETTINGS_PREFIX + "restapi.max_string_length";
+    public static final int SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT = 4096;
     // Illegal Opcodes from here on
     public static final String SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY = SECURITY_SETTINGS_PREFIX
         + "unsupported.disable_rest_auth_initially";

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
@@ -36,6 +36,7 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
+import org.opensearch.security.support.ConfigConstants;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -1150,9 +1151,15 @@ public class RequestContentValidatorTest {
 
     /* ---------------------- validateStringLength ---------------------- */
 
-    @Test
-    public void testStringLengthValidationRejectsOverMaxLength() throws Exception {
-        final RequestContentValidator validator = RequestContentValidator.of(new RequestContentValidator.ValidationContext() {
+    // Explicit, small limit used by the string-length tests so they stay fast and independent of the (large) default.
+    private static final int CONFIGURED_MAX_STRING_LENGTH = 256;
+
+    private static Settings settingsWithMaxStringLength(final int maxLength) {
+        return Settings.builder().put(ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH, maxLength).build();
+    }
+
+    private RequestContentValidator stringValidator(final Settings settings, final DataType type) {
+        return RequestContentValidator.of(new RequestContentValidator.ValidationContext() {
             @Override
             public Object[] params() {
                 return new Object[0];
@@ -1160,44 +1167,54 @@ public class RequestContentValidatorTest {
 
             @Override
             public Settings settings() {
-                return Settings.EMPTY;
+                return settings;
             }
 
             @Override
             public Map<String, FieldConfiguration> allowedKeys() {
-                return Map.of("description", FieldConfiguration.of(DataType.STRING));
+                return Map.of(
+                    "description",
+                    FieldConfiguration.of(DataType.STRING),
+                    "backend_roles",
+                    FieldConfiguration.of(DataType.ARRAY)
+                );
             }
         });
-        final JsonNode payload = DefaultObjectMapper.objectMapper()
-            .createObjectNode()
-            .put("description", repeat('a', RequestContentValidator.MAX_STRING_LENGTH + 1));
-        when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
-        final ValidationResult<JsonNode> validationResult = validator.validate(request);
-        assertFalse(validationResult.isValid());
-        assertErrorMessage(validationResult.errorMessage(), RequestContentValidator.ValidationError.STRING_EXCEEDS_MAX_LENGTH);
+    }
+
+    private void assertStringLengthError(final ValidationResult<JsonNode> validationResult, final int expectedLimit) throws IOException {
+        final JsonNode errorMessage = xContentToJsonNode(validationResult.errorMessage());
+        assertThat(errorMessage.get("status").asText(), is("error"));
+        assertThat(
+            errorMessage.get("reason").asText(),
+            is("String value exceeds the maximum allowed length of " + expectedLimit + " characters")
+        );
     }
 
     @Test
-    public void testStringLengthValidationAcceptsAtMaxLength() throws Exception {
-        final RequestContentValidator validator = RequestContentValidator.of(new RequestContentValidator.ValidationContext() {
-            @Override
-            public Object[] params() {
-                return new Object[0];
-            }
-
-            @Override
-            public Settings settings() {
-                return Settings.EMPTY;
-            }
-
-            @Override
-            public Map<String, FieldConfiguration> allowedKeys() {
-                return Map.of("description", FieldConfiguration.of(DataType.STRING));
-            }
-        });
+    public void testStringLengthValidationRejectsOverConfiguredMaxLength() throws Exception {
+        final RequestContentValidator validator = stringValidator(
+            settingsWithMaxStringLength(CONFIGURED_MAX_STRING_LENGTH),
+            DataType.STRING
+        );
         final JsonNode payload = DefaultObjectMapper.objectMapper()
             .createObjectNode()
-            .put("description", repeat('a', RequestContentValidator.MAX_STRING_LENGTH));
+            .put("description", repeat('a', CONFIGURED_MAX_STRING_LENGTH + 1));
+        when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
+        final ValidationResult<JsonNode> validationResult = validator.validate(request);
+        assertFalse(validationResult.isValid());
+        assertStringLengthError(validationResult, CONFIGURED_MAX_STRING_LENGTH);
+    }
+
+    @Test
+    public void testStringLengthValidationAcceptsAtConfiguredMaxLength() throws Exception {
+        final RequestContentValidator validator = stringValidator(
+            settingsWithMaxStringLength(CONFIGURED_MAX_STRING_LENGTH),
+            DataType.STRING
+        );
+        final JsonNode payload = DefaultObjectMapper.objectMapper()
+            .createObjectNode()
+            .put("description", repeat('a', CONFIGURED_MAX_STRING_LENGTH));
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertTrue(validationResult.isValid());
@@ -1205,55 +1222,57 @@ public class RequestContentValidatorTest {
 
     @Test
     public void testStringLengthValidationChecksNestedArrayElements() throws Exception {
-        final RequestContentValidator validator = RequestContentValidator.of(new RequestContentValidator.ValidationContext() {
-            @Override
-            public Object[] params() {
-                return new Object[0];
-            }
-
-            @Override
-            public Settings settings() {
-                return Settings.EMPTY;
-            }
-
-            @Override
-            public Map<String, FieldConfiguration> allowedKeys() {
-                return Map.of("backend_roles", FieldConfiguration.of(DataType.ARRAY));
-            }
-        });
+        final RequestContentValidator validator = stringValidator(
+            settingsWithMaxStringLength(CONFIGURED_MAX_STRING_LENGTH),
+            DataType.ARRAY
+        );
         final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
-        payload.putArray("backend_roles").add("short").add(repeat('x', RequestContentValidator.MAX_STRING_LENGTH + 1));
+        payload.putArray("backend_roles").add("short").add(repeat('x', CONFIGURED_MAX_STRING_LENGTH + 1));
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertFalse(validationResult.isValid());
-        assertErrorMessage(validationResult.errorMessage(), RequestContentValidator.ValidationError.STRING_EXCEEDS_MAX_LENGTH);
+        assertStringLengthError(validationResult, CONFIGURED_MAX_STRING_LENGTH);
     }
 
     @Test
     public void testStringLengthValidationChecksPatchedContent() throws Exception {
-        final RequestContentValidator validator = RequestContentValidator.of(new RequestContentValidator.ValidationContext() {
-            @Override
-            public Object[] params() {
-                return new Object[0];
-            }
-
-            @Override
-            public Settings settings() {
-                return Settings.EMPTY;
-            }
-
-            @Override
-            public Map<String, FieldConfiguration> allowedKeys() {
-                return Map.of("description", FieldConfiguration.of(DataType.STRING));
-            }
-        });
+        final RequestContentValidator validator = stringValidator(
+            settingsWithMaxStringLength(CONFIGURED_MAX_STRING_LENGTH),
+            DataType.STRING
+        );
         final JsonNode original = DefaultObjectMapper.objectMapper().createObjectNode().put("description", "short");
         final JsonNode patched = DefaultObjectMapper.objectMapper()
             .createObjectNode()
-            .put("description", repeat('a', RequestContentValidator.MAX_STRING_LENGTH + 1));
+            .put("description", repeat('a', CONFIGURED_MAX_STRING_LENGTH + 1));
         final ValidationResult<JsonNode> validationResult = validator.validate(request, patched, original);
         assertFalse(validationResult.isValid());
-        assertErrorMessage(validationResult.errorMessage(), RequestContentValidator.ValidationError.STRING_EXCEEDS_MAX_LENGTH);
+        assertStringLengthError(validationResult, CONFIGURED_MAX_STRING_LENGTH);
+    }
+
+    /**
+     * Regression test for issue #6434: with the default (generous) limit, a large free-form value such as a DLS query
+     * must be accepted. The pre-fix hard-coded 256 limit rejected these.
+     */
+    @Test
+    public void testStringLengthValidationDefaultAllowsLargeValue() throws Exception {
+        final RequestContentValidator validator = stringValidator(Settings.EMPTY, DataType.STRING);
+        // Comfortably larger than the old 256 limit, comfortably smaller than the default.
+        final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("description", repeat('a', 1024));
+        when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
+        final ValidationResult<JsonNode> validationResult = validator.validate(request);
+        assertTrue(validationResult.isValid());
+    }
+
+    @Test
+    public void testStringLengthValidationRejectsBeyondDefaultAndReportsDefaultLimit() throws Exception {
+        final RequestContentValidator validator = stringValidator(Settings.EMPTY, DataType.STRING);
+        final JsonNode payload = DefaultObjectMapper.objectMapper()
+            .createObjectNode()
+            .put("description", repeat('a', ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT + 1));
+        when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
+        final ValidationResult<JsonNode> validationResult = validator.validate(request);
+        assertFalse(validationResult.isValid());
+        assertStringLengthError(validationResult, ConfigConstants.SECURITY_RESTAPI_MAX_STRING_LENGTH_DEFAULT);
     }
 
 }


### PR DESCRIPTION
### Description

PR #6224 added a blanket recursive check (`RequestContentValidator#validateStringLength`) that rejects **any** string value longer than a hard-coded **256** characters *anywhere* in a Security REST API request body. While the intent was hardening against oversized inputs, 256 chars is far too small for legitimate free-form fields — most notably **DLS queries**, but also FLS/masked-field definitions, `description`, query templates, etc. On upgrade to 3.8.0.0 these requests started failing with:

```
HTTP 400 - String value exceeds the maximum allowed length of 256 characters
```

This is a breaking change for any cluster that manages roles with non-trivial DLS/FLS via the REST API (see #6434).

This PR:

- Introduces a configurable node setting **`plugins.security.restapi.max_string_length`** that controls the blanket body-wide limit.
- Raises the default from 256 to **4096**, restoring compatibility for realistic payloads while still bounding pathologically large inputs. (Jackson's own `StreamReadConstraints` remains the hard parser-level ceiling.)
- Leaves the **targeted** 256-char validators for semantically-bounded fields (entity names, principals, paths) unchanged — those limits are reasonable and are not the source of the regression.
- Makes the error response report the **effective configured limit** instead of a hard-coded 256.

Operators who want a stricter (or looser) cap can now set the value in `opensearch.yml`, e.g.:

```yaml
plugins.security.restapi.max_string_length: 8192
```

### Issues Resolved

Resolves #6434

### Testing

- Reworked the existing `validateStringLength` unit tests to drive the limit through the new setting and to assert the dynamic (limit-aware) error message.
- Added a regression test that a large free-form value is accepted under the default limit, and a test that a value beyond the default is rejected and reports the default limit.
- `./gradlew spotlessCheck checkstyleMain checkstyleTest test --tests "org.opensearch.security.dlic.rest.validation.RequestContentValidatorTest" --tests "org.opensearch.security.dlic.rest.validation.EndpointValidatorTest"` → all green, 102 tests, 0 failures.

### Backport

This should be backported to the `3.8` branch for a **3.8.0.1** patch release, since 3.8.0.0 is affected.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented (setting will be added to the documentation-website in a follow-up)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
