### PR TITLE
Only provision Eclipse JDT formatter when running a spotless task

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -1,5 +1,12 @@
 allprojects {
 	project.apply plugin: "com.diffplug.spotless"
+	// The Eclipse JDT formatter is provisioned by Spotless from a P2 update-site mirror during Gradle's
+	// configuration phase. That means every Gradle invocation - including test-only tasks that never format
+	// anything - reaches out to the mirror, which intermittently fails with a SocketTimeoutException (most
+	// often on Windows CI, where the Equo formatter cache under ~/.m2 is not persisted between runs). Only
+	// wire the Eclipse step when a spotless task is actually being run. The dedicated code-hygiene jobs always
+	// invoke spotlessApply/spotlessCheck by name, so formatting enforcement is unchanged.
+	def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
 	spotless {
 		java {
 			// Normally this isn't necessary, but we have Java sources in
@@ -14,7 +21,9 @@ allprojects {
 				'\\#java|\\#org.apache|\\#org.hamcrest|\\#org.opensearch|\\#'
 			)
 			removeUnusedImports()
-			eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+			if (runningSpotlessTask) {
+				eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+			}
 			trimTrailingWhitespace()
 			endWithNewline();
 			custom 'Replace illegal HttpStatus import w/ correct one', {


### PR DESCRIPTION
### Description

Windows `test` jobs (and any other non-`spotless` Gradle invocation) intermittently fail **during the configuration phase** with:

```
FAILURE: Build failed with an exception.
> java.io.IOException: Failed to load eclipse jdt formatter:
  java.lang.RuntimeException: java.net.SocketTimeoutException: timeout
```

**Root cause:** Spotless provisions the Eclipse JDT formatter from a P2 update-site mirror (`ci.opensearch.org`) while Gradle *configures* the project. Since `gradle/formatting.gradle` applies the `spotless` config to `allprojects`, **every** Gradle invocation reaches out to the mirror — including test-only tasks such as `dlicDlsflsTest` that never format anything. The Equo formatter cache lives under `~/.m2/repository/dev/equo` (not the Gradle cache), so on the Windows `test` matrix — which runs `setup-gradle` with `cache-disabled: true` — it is re-downloaded on every shard and intermittently times out.

**Fix:** Only wire the `eclipse()` step when a spotless task is actually requested (`gradle.startParameter.taskNames` contains `spotless`). The dedicated code-hygiene job (`./gradlew spotlessCheck`) and the dependabot job (`./gradlew spotlessApply`) always invoke spotless by name, so formatting enforcement is unchanged; test/assemble/integrationTest tasks no longer depend on the P2 mirror at all.

### Verification (local)

Cleared the Equo cache (`rm -rf ~/.m2/repository/dev/equo`) and ran an **online** non-spotless task (`./gradlew help -q`):

| | Equo re-downloaded during configuration? |
|---|---|
| **Before** (unguarded) | **Yes** — reproduces the CI dependency on the mirror |
| **After** (this PR) | **No** |

And `./gradlew spotlessCheck` still runs `spotlessJavaCheck` across all modules and passes (Eclipse formatter provisioned only for the spotless task).

### Issues Resolved

Fixes the recurring "Failed to load eclipse jdt formatter … SocketTimeoutException" configuration-phase failures on Windows CI `test` jobs.

### Check List
- [x] New functionality includes testing (verified locally as above; this is a build/CI-only change)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
