### PR TITLE
Document demo installer password checks vs REST API settings #4081

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -174,6 +174,8 @@ export OPENSEARCH_INITIAL_ADMIN_PASSWORD=<password>
 
 **_Note:_** If no password is supplied, the installation will fail. The password supplied will also be tested for its strength and will be blocked if it is too simple. There is an option to skip this password validation by passing the `-t` option to the installation script. However, this should only be used for test environments.
 
+The demo installer does not read `plugins.security.restapi.password_min_length` or `plugins.security.restapi.password_validation_regex` from `opensearch.yml`. Those settings apply later, when you create or update users through the REST API or OpenSearch Dashboards. The installer runs before the node loads cluster settings, so it uses its own checks: at least 8 characters, one uppercase letter, one lowercase letter, one digit, one special character, and a strong zxcvbn score. Changing the REST API password settings does not change what the demo script accepts for `OPENSEARCH_INITIAL_ADMIN_PASSWORD`.
+
 
 ### Executing the demo installation script
 

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -191,6 +191,8 @@ public class SecuritySettingsConfigurer {
         }
 
         try {
+            // Demo-only rules. Not plugins.security.restapi.password_* from opensearch.yml —
+            // this installer runs before those cluster settings are loaded.
             final PasswordValidator passwordValidator = PasswordValidator.of(
                 Settings.builder()
                     .put(


### PR DESCRIPTION
### Description
* Category: Documentation
* The demo installer validates `OPENSEARCH_INITIAL_ADMIN_PASSWORD` with its own length, regex, and zxcvbn checks. Those values look like `plugins.security.restapi.password_min_length` and `plugins.security.restapi.password_validation_regex`, but the script never reads `opensearch.yml`.
* Old behavior: the developer guide only said the password is checked for strength. New behavior: it states that the REST API settings do not apply to the demo admin password, and what the installer actually requires.

### Issues Resolved
Resolves #4081

Is this a backport? No

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? No

### Testing
Docs only. I checked `SecuritySettingsConfigurer` still hardcodes min length 8 and the complexity regex, and that `plugins.security.restapi.password_min_length` still defaults to -1 on the plugin settings.

### Check List
- [ ] New functionality includes testing
- [x] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
