### PR TITLE
Use a dedicated header for hybrid-query DLS instead of a marker value

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -93,7 +93,7 @@ public class DlsFilterLevelActionHandler {
         boolean applyDlsFilterToHybridQuery
     ) {
 
-        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
+        if (isDlsAlreadyHandled(threadContext)) {
             return true;
         }
 
@@ -179,10 +179,14 @@ public class DlsFilterLevelActionHandler {
         // context restores the caller's headers.
         try (StoredContext ctx = threadContext.newStoredContext(true)) {
 
-            threadContext.putHeader(
-                ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-                applyDlsFilterToHybridQuery ? ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE : "true"
-            );
+            // The two markers are mutually exclusive. OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE means the user query was
+            // wrapped and reader-level DLS can be skipped; OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED means DLS was
+            // pushed into the top-level query filter and reader-level DLS must stay active.
+            if (applyDlsFilterToHybridQuery) {
+                threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED, "true");
+            } else {
+                threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "true");
+            }
 
             try {
                 if (!modifyQuery()) {
@@ -357,6 +361,16 @@ public class DlsFilterLevelActionHandler {
             );
             return false;
         }
+    }
+
+    /**
+     * Returns true if DLS has already been applied to this request's query, either by wrapping the user query or by
+     * pushing the DLS filter into a top-level hybrid query. Both markers are coordinator-side re-entry guards: they stop
+     * the child request dispatched through {@code nodeClient} from being processed again.
+     */
+    static boolean isDlsAlreadyHandled(ThreadContext threadContext) {
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null
+            || threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED) != null;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -907,9 +907,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
     }
 
     static boolean isDlsQueryFilterApplied(ThreadContext threadContext) {
-        return ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-            threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-        );
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED) != null;
     }
 
     private boolean applyDlsHere() {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -30,7 +30,6 @@ import org.apache.lucene.util.BytesRef;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
-import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.RealtimeRequest;
 import org.opensearch.action.admin.indices.shrink.ResizeRequest;
@@ -99,7 +98,6 @@ import static org.opensearch.security.support.ConfigConstants.SECURITY_DLS_WRITE
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
     private static final String MAP_EXECUTION_HINT = "map";
-    private static final Version HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE = Version.V_3_9_0;
     private static final Logger log = LogManager.getLogger(DlsFlsValveImpl.class);
 
     private final Client nodeClient;
@@ -235,7 +233,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 return true;
             }
 
-            if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
+            if (DlsFilterLevelActionHandler.isDlsAlreadyHandled(threadContext)) {
                 if (log.isDebugEnabled()) {
                     log.debug("DLS query handling is already done for this request");
                 }
@@ -266,7 +264,6 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                         request,
                         hasDlsRestrictions,
                         containsTermLookupQuery,
-                        isHybridQueryDlsFilterSupported(clusterService.state().nodes().getMinNodeVersion()),
                         isLocalOnlyRequest(resolved)
                     );
 
@@ -455,24 +452,12 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         ActionRequest request,
         boolean hasDlsRestrictions,
         boolean containsTermLookupQuery,
-        boolean hybridQueryDlsFilterSupported,
         boolean localOnlyRequest
     ) {
         return hasDlsRestrictions
             && !containsTermLookupQuery
-            && hybridQueryDlsFilterSupported
             && localOnlyRequest
             && isTopLevelHybridQueryWithoutParentChildClauses(request);
-    }
-
-    /**
-     * The minimum OpenSearch version is only a lower bound for the Neural Search hybrid-query contract. If a future
-     * Neural Search release changes its {@code filter()} or {@code visit()} behavior, the verification in
-     * {@link DlsFilterLevelActionHandler} rejects the request rather than applying DLS incompletely. Keep the
-     * cross-plugin {@code HybridQueryDlsIT} coverage in sync with that contract.
-     */
-    static boolean isHybridQueryDlsFilterSupported(Version minNodeVersion) {
-        return minNodeVersion != null && minNodeVersion.onOrAfter(HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE);
     }
 
     static boolean isLocalOnlyRequest(OptionallyResolvedIndices resolved) {
@@ -557,10 +542,11 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
             if (!dlsRestriction.isUnrestricted()) {
                 if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
-                    // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here.
-                    // DlsFlsFilterLeafReader sees the hybrid value on OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE and
-                    // retains the existing reader-level DLS behavior for aggregations, suggestions, and other paths.
-                    // This check intentionally follows the star-tree safeguard above.
+                    // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here
+                    // and would break the requirement that the hybrid query stays top-level. Reader-level DLS stays
+                    // active because OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE was not set, so
+                    // SecurityFlsDlsIndexSearcherWrapper still builds a DLS query for aggregations and other paths that
+                    // do not rely on the top-level query. This check intentionally follows the star-tree safeguard above.
                     log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                     return;
                 }

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
@@ -64,13 +64,16 @@ public class DlsFlsBaseContext {
     }
 
     public boolean isDlsDoneOnFilterLevel() {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null && !isDlsQueryFilterApplied();
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null;
     }
 
+    /**
+     * Returns true if the DLS restriction was applied through the top-level query filter. In that case the query itself
+     * protects hits, but reader-level DLS must stay active for search paths which do not rely on the top-level query,
+     * such as global aggregations.
+     */
     public boolean isDlsQueryFilterApplied() {
-        return ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-            threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-        );
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED) != null;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -72,7 +72,16 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
-    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "hybrid_query";
+
+    /**
+     * Marks a request whose DLS restriction was applied through the top-level query filter instead of by wrapping the
+     * user query. This is a dedicated header rather than a value of OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE so that a
+     * node which does not understand it simply sees no marker and falls back to its normal reader-level DLS handling.
+     * Overloading OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE would instead make such a node treat DLS as fully handled
+     * and skip reader-level DLS altogether.
+     */
+    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED = OPENDISTRO_SECURITY_CONFIG_PREFIX
+        + "hybrid_query_dls_applied";
     public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";
 
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_CCS = OPENDISTRO_SECURITY_CONFIG_PREFIX + "dls_query_ccs";

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -202,6 +202,7 @@ public class SecurityInterceptor {
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER)
                             || k.equals(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS)
@@ -222,13 +223,10 @@ public class SecurityInterceptor {
             boolean isDestinationOutsideLocalCluster = clusterInfoHolder.isInitialized()
                 && !clusterInfoHolder.hasNode(connection.getNode());
 
-            if (isDestinationOutsideLocalCluster
-                && ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-                    headerMap.get(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-                )) {
+            if (isDestinationOutsideLocalCluster) {
                 // The top-level query filter is only valid within the coordinating cluster. Strip its marker from every
                 // action sent to an unrecognized destination, even if RemoteClusterService does not report CCS as enabled.
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED);
             }
 
             if (isCrossClusterSearchEnabled() && isSearchAction && isDestinationOutsideLocalCluster) {

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -491,12 +491,12 @@ public class DlsFilterLevelActionHandlerTest {
 
     @Test
     public void filterLevelDlsMarkerPreventsReentry() {
-        assertDlsMarkerPreventsReentry("true");
+        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
     }
 
     @Test
     public void hybridQueryDlsMarkerPreventsReentry() {
-        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
+        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED);
     }
 
     @Test
@@ -562,10 +562,8 @@ public class DlsFilterLevelActionHandlerTest {
         when(context.getResolvedIndices()).thenReturn(ResolvedIndices.of("index"));
         when(clusterService.state()).thenReturn(mock(ClusterState.class));
         doAnswer(invocation -> {
-            assertThat(
-                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
-                is(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE)
-            );
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED), is("true"));
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
             return null;
         }).when(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
 
@@ -682,9 +680,9 @@ public class DlsFilterLevelActionHandlerTest {
         }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
     }
 
-    private static void assertDlsMarkerPreventsReentry(String value) {
+    private static void assertDlsMarkerPreventsReentry(String markerHeader) {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, value);
+        threadContext.putHeader(markerHeader, "true");
 
         boolean result = DlsFilterLevelActionHandler.handle(null, null, null, null, null, null, threadContext, false);
 

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
@@ -28,10 +28,7 @@ public class DlsFlsFilterLeafReaderTest {
         ThreadContext filterLevelContext = new ThreadContext(Settings.EMPTY);
         filterLevelContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "true");
         ThreadContext hybridContext = new ThreadContext(Settings.EMPTY);
-        hybridContext.putHeader(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
+        hybridContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED, "true");
 
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(unmarkedContext), is(false));
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(filterLevelContext), is(false));

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -83,7 +83,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(true));
     }
@@ -101,7 +101,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, true, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, true, true);
 
         assertThat(result, is(false));
     }
@@ -126,7 +126,7 @@ public class DlsFlsValveImplTest {
         Level previousLevel = logger.getLevel();
         logger.setLevel(Level.DEBUG);
         try {
-            assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
+            assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED);
         } finally {
             logger.setLevel(previousLevel);
         }
@@ -134,12 +134,12 @@ public class DlsFlsValveImplTest {
 
     @Test
     public void filterLevelDlsMarkerPreventsValveReentry() throws Exception {
-        assertDlsMarkerPreventsValveReentry("true");
+        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
     }
 
-    private static void assertDlsMarkerPreventsValveReentry(String value) throws Exception {
+    private static void assertDlsMarkerPreventsValveReentry(String markerHeader) throws Exception {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, value);
+        threadContext.putHeader(markerHeader, "true");
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -187,7 +187,7 @@ public class DlsFlsValveImplTest {
 
     @Test
     public void usesLuceneLevelDlsWhenSearchHasNoSourceInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(new SearchRequest(), true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(new SearchRequest(), true, false, true);
 
         assertThat(result, is(false));
     }
@@ -196,20 +196,14 @@ public class DlsFlsValveImplTest {
     public void usesLuceneLevelDlsWhenSearchSourceHasNoQueryInAdaptiveMode() {
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource());
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(false));
     }
 
     @Test
     public void usesLuceneLevelDlsForNonSearchRequestInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(
-            mock(ActionRequest.class),
-            true,
-            false,
-            true,
-            true
-        );
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(mock(ActionRequest.class), true, false, true);
 
         assertThat(result, is(false));
     }
@@ -220,18 +214,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, false, false, true, true);
-
-        assertThat(result, is(false));
-    }
-
-    @Test
-    public void doesNotApplyHybridQueryFilterWhenClusterContainsOlderNode() {
-        QueryBuilder hybridQuery = mock(QueryBuilder.class);
-        when(hybridQuery.getName()).thenReturn("hybrid");
-        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
-
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, false, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, false, false, true);
 
         assertThat(result, is(false));
     }
@@ -242,7 +225,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, false);
 
         assertThat(result, is(false));
     }
@@ -254,7 +237,7 @@ public class DlsFlsValveImplTest {
         BoolQueryBuilder outerQuery = new BoolQueryBuilder().must(hybridQuery);
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(outerQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(false));
     }
@@ -272,16 +255,9 @@ public class DlsFlsValveImplTest {
         }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(false));
-    }
-
-    @Test
-    public void hybridQueryDlsFilterRequiresOpenSearchThreeNineOnEveryNode() {
-        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(null), is(false));
-        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_8_0), is(false));
-        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_9_0), is(true));
     }
 
     @Test
@@ -324,7 +300,7 @@ public class DlsFlsValveImplTest {
             false,
             Version.V_2_19_0,
             DlsFlsValveImpl.Mode.FILTER_LEVEL.name(),
-            "true"
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE
         );
 
         assertThat(threadContext.getTransient(DlsFlsLegacyHeaders.TRANSIENT_HEADER), instanceOf(DlsFlsLegacyHeaders.class));
@@ -352,7 +328,7 @@ public class DlsFlsValveImplTest {
             expectedResult,
             Version.V_3_9_0,
             null,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED
         );
     }
 
@@ -362,7 +338,7 @@ public class DlsFlsValveImplTest {
         boolean expectedResult,
         Version minNodeVersion,
         String dlsModeHeader,
-        String expectedCompletionMarker
+        String expectedMarkerHeader
     ) throws Exception {
         return invokeAdaptiveDlsValve(
             query,
@@ -370,7 +346,7 @@ public class DlsFlsValveImplTest {
             expectedResult,
             minNodeVersion,
             dlsModeHeader,
-            expectedCompletionMarker,
+            expectedMarkerHeader,
             true,
             false
         );
@@ -382,7 +358,7 @@ public class DlsFlsValveImplTest {
         boolean expectedResult,
         Version minNodeVersion,
         String dlsModeHeader,
-        String expectedCompletionMarker,
+        String expectedMarkerHeader,
         boolean hasDlsRestrictions,
         boolean hasFlsRestrictions
     ) throws Exception {
@@ -452,7 +428,15 @@ public class DlsFlsValveImplTest {
         @SuppressWarnings("unchecked")
         ActionListener<Object> listener = mock(ActionListener.class);
         doAnswer(invocation -> {
-            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is(expectedCompletionMarker));
+            // Exactly one marker is set while the child search runs, and it identifies which DLS path was taken.
+            assertThat(
+                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
+                is(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE.equals(expectedMarkerHeader) ? "true" : null)
+            );
+            assertThat(
+                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED),
+                is(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED.equals(expectedMarkerHeader) ? "true" : null)
+            );
             return null;
         }).when(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
         DlsFlsValveImpl valve = new DlsFlsValveImpl(
@@ -470,6 +454,7 @@ public class DlsFlsValveImplTest {
         boolean result = valve.invoke(context, listener);
 
         assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+        assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED), is((String) null));
         if (expectedResult) {
             assertThat(searchRequest.source().query(), sameInstance(query));
             verify(nodeClient, never()).search(

--- a/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
+++ b/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
@@ -30,10 +30,7 @@ public class DlsFlsBaseContextTest {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));
 
-        threadContext.putHeader(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
+        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED, "true");
 
         assertThat(context.isDlsQueryFilterApplied(), is(true));
         assertThat(context.isDlsDoneOnFilterLevel(), is(false));

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -486,8 +486,7 @@ public class SecurityInterceptorTests {
     @Test
     public void testHybridQueryDlsStateIsCopiedToLocalNodes() {
         enableCrossClusterSearch();
-        String headerValue = ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE;
-        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, headerValue);
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED, "true");
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(localNode)).thenReturn(true);
         when(clusterInfoHolder.hasNode(otherNode)).thenReturn(true);
@@ -502,8 +501,8 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 assertThat(
-                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
-                    is(headerValue)
+                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED),
+                    is("true")
                 );
                 senderLatch.get().countDown();
             }
@@ -543,11 +542,7 @@ public class SecurityInterceptorTests {
     }
 
     private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(String action) {
-        threadPool.getThreadContext()
-            .putHeader(
-                ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-                ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-            );
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED, "true");
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
 
@@ -560,7 +555,7 @@ public class SecurityInterceptorTests {
                 TransportRequestOptions options,
                 TransportResponseHandler<T> handler
             ) {
-                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE));
+                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED));
                 senderLatch.get().countDown();
             }
         };


### PR DESCRIPTION
### Description

* Category: Refactoring

Follow-up to #6416. That PR is correct on a fully-upgraded cluster, but it signals its state through a sentinel *value* stored in an existing header, and that choice is what forces the `Version.V_3_9_0` gate to exist. This replaces the sentinel with a dedicated header so the mechanism is fail-safe on its own, and removes the version gate.

No behavior change on a cluster where every node has the fix.

#### Why the sentinel value needs a version gate

#6416 wrote the marker as a value of `OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE` and redefined `isDlsDoneOnFilterLevel()` to exclude it:

```java
public boolean isDlsDoneOnFilterLevel() {
    return threadContext.getHeader(...FILTER_LEVEL_DLS_DONE) != null && !isDlsQueryFilterApplied();
}
```

That header is transport-propagated to data nodes. On a node that predates the sentinel, the original definition applies — any non-null value means "filter-level DLS handled this request" — and the consumer that matters is `SecurityFlsDlsIndexSearcherWrapper`:

```java
if (!this.dlsFlsBaseContext.isDlsDoneOnFilterLevel()) {
    dlsRestriction = config.getDocumentPrivileges().getRestriction(privilegesEvaluationContext, index.getName());
} else {
    dlsRestriction = DlsRestriction.NONE;
}
```

So that shard takes `DlsRestriction.NONE`, builds no `dlsQuery`, and applies no reader-level DLS. Hits are still protected by the DLS filter pushed into the hybrid subqueries, but a `global` aggregation is not, because a global aggregation ignores the top-level query by definition — and retaining reader-level DLS for exactly that case is the stated purpose of the marker.

The design fails **open**, which is why it needs the version gate to be correct.

#### What this changes

Use a dedicated `OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_APPLIED` header instead of overloading the existing one. A node that does not know the header sees *absence*, and absence means "do the normal thing" — compute the restriction, build the DLS query, apply reader-level DLS. The mechanism fails **closed** by construction, so there is nothing left to version-gate.

* `isDlsDoneOnFilterLevel()` returns to a plain null check. Its four callers keep their original meaning, including the untouched `SecurityFlsDlsIndexSearcherWrapper`.
* `HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE` and `isHybridQueryDlsFilterSupported` are removed, dropping one gate from `shouldApplyDlsFilterToHybridQueryInAdaptiveMode` and the `Version` import from `DlsFlsValveImpl`.
* New `isDlsAlreadyHandled()` backs the two coordinator-side re-entry guards, which now consult both markers. These stop the child request dispatched through `nodeClient` from being reprocessed and run only on the coordinating node, so they carry no compatibility exposure.
* `SecurityInterceptor` copies the new header to local destinations and strips it for destinations outside the local cluster. The strip is now an unconditional `remove` of our own key rather than a conditional edit of a shared header's value.
* The tri-state string becomes two independent, mutually exclusive booleans.

The runtime verification in `applyFilterLevelDls` is unchanged. It is still what actually guarantees the Neural Search hybrid-query contract, and it needs no version information.

#### Why this matters for backports

A `Version` comparison cannot express "has the fix" across several release lines at once:

1. The constant differs per branch, so `DlsFlsValveImpl` diverges and conflicts on every later backport touching the file.
2. Patch granularity. A `3.5.0` GA would not contain the fix, so `V_3_5_0` is too permissive and reopens the gap, while `V_3_5_4` requires a constant that OpenSearch core may not have declared yet.
3. It defeats its own backport. On `main`, `minNodeVersion.onOrAfter(V_3_9_0)` is false for a 3.7-with-fix + 3.9 cluster, disabling the fix on exactly the mixed-version clusters a backport is meant to serve.

Without a version constant, the identical patch applies to every release line.

#### Mixed-version behavior

Shards on nodes with the fix return correct results. Shards on nodes without it wrap the parsed query as they do today and fail the hybrid-query shape, so the request surfaces a shard failure — the same class of failure as the bug #6416 fixed, and never a silent loss of reader-level DLS. This is a documentable rolling-upgrade limitation rather than a security regression, which the sentinel-value design could not offer.

### Issues Resolved

Follow-up to #6416. No new issue; this hardens and simplifies the mechanism introduced there and unblocks backporting it.

### Testing

`./gradlew test` for the five affected suites: **87 tests, 0 failures, 0 skipped.**

```bash
./gradlew test \
  --tests org.opensearch.security.configuration.DlsFlsFilterLeafReaderTest \
  --tests org.opensearch.security.configuration.DlsFilterLevelActionHandlerTest \
  --tests org.opensearch.security.configuration.DlsFlsValveImplTest \
  --tests org.opensearch.security.privileges.dlsfls.DlsFlsBaseContextTest \
  --tests org.opensearch.security.transport.SecurityInterceptorTests
```

Test changes:

* Removed `hybridQueryDlsFilterRequiresOpenSearchThreeNineOnEveryNode` and `doesNotApplyHybridQueryFilterWhenClusterContainsOlderNode`, which covered the deleted gate.
* The valve helper now asserts on the marker *header* and that exactly one of the two markers is set while the child search runs.
* Re-entry tests parameterize on the header key rather than the header value.
* `SecurityInterceptorTests` asserts the new header is copied to local nodes and stripped for an unrecognized destination.

`./gradlew precommit` passes except for two failures that reproduce identically on unmodified `main` (verified by stashing this change and re-running) and involve no file touched here:

* `:licenseHeaders` — 38 pre-existing unapproved headers under `auth/**` and `ssl/**`.
* `:opensearch-sample-resource-plugin:forbiddenApisMain` — `URL#openStream()` in `CreateResourceTransportAction:77` and `CreateResourceGroupTransportAction:70`.

#### Cross-plugin verification

Published this branch to Maven Local and ran opensearch-project/neural-search#1957's `HybridQueryDlsIT` on a **three-node secured cluster**, which is what actually exercises the header crossing the transport layer:

```bash
cd security && ./gradlew publishPluginZipPublicationToMavenLocal
cd neural-search && ./gradlew :integTest \
  --tests org.opensearch.neuralsearch.query.HybridQueryDlsIT \
  -x spotlessApply -Dsecurity.enabled=true -PnumNodes=3 --refresh-dependencies
```

| Test | Result |
| --- | --- |
| `testDlsFiltersHybridHitsAndAggregations` | PASSED |
| `testDlsSupportsSuggestionBearingHybridRequest` | PASSED |
| `testDlsCombinesWithExistingHybridFilter` | PASSED |
| `testDlsSupportsSingleClauseHybridQuery` | PASSED |
| `testDlsFiltersHybridKnnQuery` | Fails on this branch alone; passes with #6428 stacked — see below |
| `testDlsFiltersHybridNeuralQuery` | Blocked by #6433 (ML model registration), both with and without this change |

`testDlsFiltersHybridHitsAndAggregations` is the important one: it covers the DLS-protected global aggregation, which is precisely the behavior the version gate existed to protect, and it passes across three nodes with the dedicated header. That confirms the header propagates through the `SecurityInterceptor` copy allowlist and that reader-level DLS stays active on non-coordinating shards.

`testDlsFiltersHybridKnnQuery` fails on this branch with `Hybrid query did not apply the DLS filter to every subquery`. I re-ran it against an unmodified `main` build and got a byte-identical failure reason, so it is pre-existing and depends on the neural/k-NN filter traversal in #6428, not on this refactor.

#### Interaction with #6428 (verified, not assumed)

I merged #6428 into this branch on a scratch branch and ran the full suite, rather than just eyeballing the overlap.

The merge produced exactly two conflicts, both trivial:

* `DlsFlsValveImpl` — #6428 rewrites the javadoc of `isHybridQueryDlsFilterSupported`, a method this PR deletes. Resolved by taking the deletion.
* `DlsFilterLevelActionHandlerTest` — #6428 adds stub helpers adjacent to `assertDlsMarkerPreventsReentry`, whose signature this PR changed. Resolved by keeping both.

`DlsFilterLevelActionHandler` itself — #6428's substantive +120 lines — auto-merged with no conflict, because its neural/k-NN filter discovery does not care how the marker is stored.

Stacked results:

* Unit: **108 tests, 0 failures** (#6428 contributes 21 additional cases to `DlsFilterLevelActionHandlerTest`).
* `HybridQueryDlsIT`: **5 of 6 pass**, including `testDlsFiltersHybridKnnQuery`. The remaining failure is `testDlsFiltersHybridNeuralQuery`, which fails during ML model registration with `Direct self-reference leading to cycle ... org.opensearch.security.user.User` — that is #6433, unrelated to DLS.

That 5-of-6 result matches what #1957 reports for #6428 on its own, so this refactor neither improves nor regresses #6428's coverage. Whichever of the two merges first, the second rebases with a two-line resolution.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented — the compatibility rationale is documented on the new constant and in the code comments; no user-facing setting or API changes
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR — N/A
- [x] API changes companion pull request created — N/A
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
