### PR TITLE
Keep hybrid DLS safe across mixed versions

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -93,7 +93,8 @@ public class DlsFilterLevelActionHandler {
         boolean applyDlsFilterToHybridQuery
     ) {
 
-        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
+        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null
+            || threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null) {
             return true;
         }
 
@@ -180,8 +181,10 @@ public class DlsFilterLevelActionHandler {
         try (StoredContext ctx = threadContext.newStoredContext(true)) {
 
             threadContext.putHeader(
-                ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-                applyDlsFilterToHybridQuery ? ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE : "true"
+                applyDlsFilterToHybridQuery
+                    ? ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED
+                    : ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+                "true"
             );
 
             try {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -907,9 +907,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
     }
 
     static boolean isDlsQueryFilterApplied(ThreadContext threadContext) {
-        return ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-            threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-        );
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
     }
 
     private boolean applyDlsHere() {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -71,7 +71,6 @@ import org.opensearch.index.mapper.FieldNamesFieldMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.compliance.FieldReadCallback;
-import org.opensearch.security.privileges.dlsfls.DlsFlsBaseContext;
 import org.opensearch.security.privileges.dlsfls.FieldMasking;
 import org.opensearch.security.privileges.dlsfls.FieldPrivileges;
 import org.opensearch.security.privileges.dlsfls.FlsStoredFieldVisitor;
@@ -908,7 +907,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
     }
 
     static boolean isDlsQueryFilterApplied(ThreadContext threadContext) {
-        return DlsFlsBaseContext.isDlsQueryFilterApplied(threadContext);
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
     }
 
     private boolean applyDlsHere() {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -71,6 +71,7 @@ import org.opensearch.index.mapper.FieldNamesFieldMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.compliance.FieldReadCallback;
+import org.opensearch.security.privileges.dlsfls.DlsFlsBaseContext;
 import org.opensearch.security.privileges.dlsfls.FieldMasking;
 import org.opensearch.security.privileges.dlsfls.FieldPrivileges;
 import org.opensearch.security.privileges.dlsfls.FlsStoredFieldVisitor;
@@ -907,7 +908,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
     }
 
     static boolean isDlsQueryFilterApplied(ThreadContext threadContext) {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
+        return DlsFlsBaseContext.isDlsQueryFilterApplied(threadContext);
     }
 
     private boolean applyDlsHere() {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -30,7 +30,6 @@ import org.apache.lucene.util.BytesRef;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
-import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.RealtimeRequest;
 import org.opensearch.action.admin.indices.shrink.ResizeRequest;
@@ -99,7 +98,6 @@ import static org.opensearch.security.support.ConfigConstants.SECURITY_DLS_WRITE
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
     private static final String MAP_EXECUTION_HINT = "map";
-    private static final Version HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE = Version.V_3_9_0;
     private static final Logger log = LogManager.getLogger(DlsFlsValveImpl.class);
 
     private final Client nodeClient;
@@ -235,7 +233,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 return true;
             }
 
-            if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
+            if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null
+                || threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null) {
                 if (log.isDebugEnabled()) {
                     log.debug("DLS query handling is already done for this request");
                 }
@@ -266,7 +265,6 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                         request,
                         hasDlsRestrictions,
                         containsTermLookupQuery,
-                        isHybridQueryDlsFilterSupported(clusterService.state().nodes().getMinNodeVersion()),
                         isLocalOnlyRequest(resolved)
                     );
 
@@ -455,24 +453,12 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         ActionRequest request,
         boolean hasDlsRestrictions,
         boolean containsTermLookupQuery,
-        boolean hybridQueryDlsFilterSupported,
         boolean localOnlyRequest
     ) {
         return hasDlsRestrictions
             && !containsTermLookupQuery
-            && hybridQueryDlsFilterSupported
             && localOnlyRequest
             && isTopLevelHybridQueryWithoutParentChildClauses(request);
-    }
-
-    /**
-     * The minimum OpenSearch version is only a lower bound for the Neural Search hybrid-query contract. If a future
-     * Neural Search release changes its {@code filter()} or {@code visit()} behavior, the verification in
-     * {@link DlsFilterLevelActionHandler} rejects the request rather than applying DLS incompletely. Keep the
-     * cross-plugin {@code HybridQueryDlsIT} coverage in sync with that contract.
-     */
-    static boolean isHybridQueryDlsFilterSupported(Version minNodeVersion) {
-        return minNodeVersion != null && minNodeVersion.onOrAfter(HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE);
     }
 
     static boolean isLocalOnlyRequest(OptionallyResolvedIndices resolved) {
@@ -558,8 +544,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             if (!dlsRestriction.isUnrestricted()) {
                 if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
                     // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here.
-                    // DlsFlsFilterLeafReader sees the hybrid value on OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE and
-                    // retains the existing reader-level DLS behavior for aggregations, suggestions, and other paths.
+                    // The dedicated marker keeps reader-level DLS active for aggregations, suggestions, and other paths.
                     // This check intentionally follows the star-tree safeguard above.
                     log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                     return;

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -544,8 +544,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             if (!dlsRestriction.isUnrestricted()) {
                 if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
                     // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here.
-                    // The dedicated marker, or its legacy rolling-upgrade value, keeps reader-level DLS active for
-                    // aggregations, suggestions, and other paths.
+                    // The dedicated marker keeps reader-level DLS active for aggregations, suggestions, and other paths.
                     // This check intentionally follows the star-tree safeguard above.
                     log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                     return;

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -544,7 +544,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             if (!dlsRestriction.isUnrestricted()) {
                 if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
                     // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here.
-                    // The dedicated marker keeps reader-level DLS active for aggregations, suggestions, and other paths.
+                    // The dedicated marker, or its legacy rolling-upgrade value, keeps reader-level DLS active for
+                    // aggregations, suggestions, and other paths.
                     // This check intentionally follows the star-tree safeguard above.
                     log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                     return;

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
@@ -64,13 +64,11 @@ public class DlsFlsBaseContext {
     }
 
     public boolean isDlsDoneOnFilterLevel() {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null && !isDlsQueryFilterApplied();
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null;
     }
 
     public boolean isDlsQueryFilterApplied() {
-        return ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-            threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-        );
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
@@ -64,11 +64,19 @@ public class DlsFlsBaseContext {
     }
 
     public boolean isDlsDoneOnFilterLevel() {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null;
+        String filterLevelDlsDone = threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+        return filterLevelDlsDone != null && !ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(filterLevelDlsDone);
     }
 
     public boolean isDlsQueryFilterApplied() {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
+        return isDlsQueryFilterApplied(threadContext);
+    }
+
+    public static boolean isDlsQueryFilterApplied(ThreadContext threadContext) {
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null
+            || ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
+                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+            );
     }
 
     /**

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
@@ -64,19 +64,11 @@ public class DlsFlsBaseContext {
     }
 
     public boolean isDlsDoneOnFilterLevel() {
-        String filterLevelDlsDone = threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
-        return filterLevelDlsDone != null && !ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(filterLevelDlsDone);
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null;
     }
 
     public boolean isDlsQueryFilterApplied() {
-        return isDlsQueryFilterApplied(threadContext);
-    }
-
-    public static boolean isDlsQueryFilterApplied(ThreadContext threadContext) {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null
-            || ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-            );
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -72,6 +72,8 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
+    /** Legacy wire value accepted from unpatched nodes during rolling upgrades. Patched nodes must not write it. */
+    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "hybrid_query";
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED = OPENDISTRO_SECURITY_CONFIG_PREFIX
         + "dls_query_filter_applied";
     public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -72,8 +72,6 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
-    /** Legacy wire value accepted from unpatched nodes during rolling upgrades. Patched nodes must not write it. */
-    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "hybrid_query";
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED = OPENDISTRO_SECURITY_CONFIG_PREFIX
         + "dls_query_filter_applied";
     public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -72,7 +72,8 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
-    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "hybrid_query";
+    public static final String OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED = OPENDISTRO_SECURITY_CONFIG_PREFIX
+        + "dls_query_filter_applied";
     public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";
 
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_CCS = OPENDISTRO_SECURITY_CONFIG_PREFIX + "dls_query_ccs";

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -227,11 +227,6 @@ public class SecurityInterceptor {
                 // The top-level query filter is only valid within the coordinating cluster. Strip its marker from every
                 // action sent to an unrecognized destination, even if RemoteClusterService does not report CCS as enabled.
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
-                if (ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-                    headerMap.get(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-                )) {
-                    headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
-                }
             }
 
             if (isCrossClusterSearchEnabled() && isSearchAction && isDestinationOutsideLocalCluster) {

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -202,6 +202,7 @@ public class SecurityInterceptor {
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER)
                             || k.equals(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS)
@@ -222,13 +223,10 @@ public class SecurityInterceptor {
             boolean isDestinationOutsideLocalCluster = clusterInfoHolder.isInitialized()
                 && !clusterInfoHolder.hasNode(connection.getNode());
 
-            if (isDestinationOutsideLocalCluster
-                && ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
-                    headerMap.get(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-                )) {
+            if (isDestinationOutsideLocalCluster) {
                 // The top-level query filter is only valid within the coordinating cluster. Strip its marker from every
                 // action sent to an unrecognized destination, even if RemoteClusterService does not report CCS as enabled.
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
             }
 
             if (isCrossClusterSearchEnabled() && isSearchAction && isDestinationOutsideLocalCluster) {
@@ -245,10 +243,9 @@ public class SecurityInterceptor {
             }
 
             if (isCrossClusterSearchEnabled()
-                && clusterInfoHolder.isInitialized()
                 && !action.startsWith("internal:")
                 && !action.equals(ClusterSearchShardsAction.NAME)
-                && !clusterInfoHolder.hasNode(connection.getNode())) {
+                && isDestinationOutsideLocalCluster) {
 
                 if (isDebugEnabled) {
                     log.debug("add dls/fls/mf from transient");

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -227,6 +227,11 @@ public class SecurityInterceptor {
                 // The top-level query filter is only valid within the coordinating cluster. Strip its marker from every
                 // action sent to an unrecognized destination, even if RemoteClusterService does not report CCS as enabled.
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
+                if (ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
+                    headerMap.get(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+                )) {
+                    headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+                }
             }
 
             if (isCrossClusterSearchEnabled() && isSearchAction && isDestinationOutsideLocalCluster) {

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -491,12 +491,12 @@ public class DlsFilterLevelActionHandlerTest {
 
     @Test
     public void filterLevelDlsMarkerPreventsReentry() {
-        assertDlsMarkerPreventsReentry("true");
+        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
     }
 
     @Test
     public void hybridQueryDlsMarkerPreventsReentry() {
-        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
+        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
     }
 
     @Test
@@ -562,10 +562,8 @@ public class DlsFilterLevelActionHandlerTest {
         when(context.getResolvedIndices()).thenReturn(ResolvedIndices.of("index"));
         when(clusterService.state()).thenReturn(mock(ClusterState.class));
         doAnswer(invocation -> {
-            assertThat(
-                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
-                is(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE)
-            );
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED), is("true"));
             return null;
         }).when(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
 
@@ -588,6 +586,7 @@ public class DlsFilterLevelActionHandlerTest {
 
             assertThat(result, is(false));
             assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED), is((String) null));
             assertThat(searchRequest.source().query(), sameInstance(filteredHybridQuery));
             verify(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
         } finally {
@@ -630,6 +629,7 @@ public class DlsFilterLevelActionHandlerTest {
 
         assertThat(result, is(false));
         assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+        assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED), is((String) null));
         verify(listener).onFailure(
             org.mockito.ArgumentMatchers.argThat(
                 exception -> exception instanceof OpenSearchSecurityException
@@ -682,9 +682,9 @@ public class DlsFilterLevelActionHandlerTest {
         }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
     }
 
-    private static void assertDlsMarkerPreventsReentry(String value) {
+    private static void assertDlsMarkerPreventsReentry(String header) {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, value);
+        threadContext.putHeader(header, "true");
 
         boolean result = DlsFilterLevelActionHandler.handle(null, null, null, null, null, null, threadContext, false);
 

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
@@ -28,10 +28,7 @@ public class DlsFlsFilterLeafReaderTest {
         ThreadContext filterLevelContext = new ThreadContext(Settings.EMPTY);
         filterLevelContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "true");
         ThreadContext hybridContext = new ThreadContext(Settings.EMPTY);
-        hybridContext.putHeader(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
+        hybridContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
 
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(unmarkedContext), is(false));
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(filterLevelContext), is(false));

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
@@ -29,10 +29,16 @@ public class DlsFlsFilterLeafReaderTest {
         filterLevelContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "true");
         ThreadContext hybridContext = new ThreadContext(Settings.EMPTY);
         hybridContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+        ThreadContext legacyHybridContext = new ThreadContext(Settings.EMPTY);
+        legacyHybridContext.putHeader(
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
 
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(unmarkedContext), is(false));
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(filterLevelContext), is(false));
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(hybridContext), is(true));
+        assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(legacyHybridContext), is(true));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
@@ -29,16 +29,10 @@ public class DlsFlsFilterLeafReaderTest {
         filterLevelContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "true");
         ThreadContext hybridContext = new ThreadContext(Settings.EMPTY);
         hybridContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
-        ThreadContext legacyHybridContext = new ThreadContext(Settings.EMPTY);
-        legacyHybridContext.putHeader(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
 
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(unmarkedContext), is(false));
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(filterLevelContext), is(false));
         assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(hybridContext), is(true));
-        assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(legacyHybridContext), is(true));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -83,7 +83,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(true));
     }
@@ -101,7 +101,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, true, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, true, true);
 
         assertThat(result, is(false));
     }
@@ -126,7 +126,7 @@ public class DlsFlsValveImplTest {
         Level previousLevel = logger.getLevel();
         logger.setLevel(Level.DEBUG);
         try {
-            assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
+            assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
         } finally {
             logger.setLevel(previousLevel);
         }
@@ -134,12 +134,12 @@ public class DlsFlsValveImplTest {
 
     @Test
     public void filterLevelDlsMarkerPreventsValveReentry() throws Exception {
-        assertDlsMarkerPreventsValveReentry("true");
+        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
     }
 
-    private static void assertDlsMarkerPreventsValveReentry(String value) throws Exception {
+    private static void assertDlsMarkerPreventsValveReentry(String header) throws Exception {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, value);
+        threadContext.putHeader(header, "true");
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
@@ -187,7 +187,7 @@ public class DlsFlsValveImplTest {
 
     @Test
     public void usesLuceneLevelDlsWhenSearchHasNoSourceInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(new SearchRequest(), true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(new SearchRequest(), true, false, true);
 
         assertThat(result, is(false));
     }
@@ -196,20 +196,14 @@ public class DlsFlsValveImplTest {
     public void usesLuceneLevelDlsWhenSearchSourceHasNoQueryInAdaptiveMode() {
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource());
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(false));
     }
 
     @Test
     public void usesLuceneLevelDlsForNonSearchRequestInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(
-            mock(ActionRequest.class),
-            true,
-            false,
-            true,
-            true
-        );
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(mock(ActionRequest.class), true, false, true);
 
         assertThat(result, is(false));
     }
@@ -220,18 +214,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, false, false, true, true);
-
-        assertThat(result, is(false));
-    }
-
-    @Test
-    public void doesNotApplyHybridQueryFilterWhenClusterContainsOlderNode() {
-        QueryBuilder hybridQuery = mock(QueryBuilder.class);
-        when(hybridQuery.getName()).thenReturn("hybrid");
-        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
-
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, false, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, false, false, true);
 
         assertThat(result, is(false));
     }
@@ -242,7 +225,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, false);
 
         assertThat(result, is(false));
     }
@@ -254,7 +237,7 @@ public class DlsFlsValveImplTest {
         BoolQueryBuilder outerQuery = new BoolQueryBuilder().must(hybridQuery);
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(outerQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(false));
     }
@@ -272,16 +255,9 @@ public class DlsFlsValveImplTest {
         }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(false));
-    }
-
-    @Test
-    public void hybridQueryDlsFilterRequiresOpenSearchThreeNineOnEveryNode() {
-        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(null), is(false));
-        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_8_0), is(false));
-        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_9_0), is(true));
     }
 
     @Test
@@ -324,7 +300,7 @@ public class DlsFlsValveImplTest {
             false,
             Version.V_2_19_0,
             DlsFlsValveImpl.Mode.FILTER_LEVEL.name(),
-            "true"
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE
         );
 
         assertThat(threadContext.getTransient(DlsFlsLegacyHeaders.TRANSIENT_HEADER), instanceOf(DlsFlsLegacyHeaders.class));
@@ -336,7 +312,7 @@ public class DlsFlsValveImplTest {
             new BoolQueryBuilder(),
             null,
             true,
-            Version.V_3_9_0,
+            Version.CURRENT,
             DlsFlsValveImpl.Mode.FILTER_LEVEL.name(),
             null,
             false,
@@ -350,9 +326,9 @@ public class DlsFlsValveImplTest {
             query,
             expectedQuery,
             expectedResult,
-            Version.V_3_9_0,
+            Version.CURRENT,
             null,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+            ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED
         );
     }
 
@@ -362,7 +338,7 @@ public class DlsFlsValveImplTest {
         boolean expectedResult,
         Version minNodeVersion,
         String dlsModeHeader,
-        String expectedCompletionMarker
+        String expectedCompletionHeader
     ) throws Exception {
         return invokeAdaptiveDlsValve(
             query,
@@ -370,7 +346,7 @@ public class DlsFlsValveImplTest {
             expectedResult,
             minNodeVersion,
             dlsModeHeader,
-            expectedCompletionMarker,
+            expectedCompletionHeader,
             true,
             false
         );
@@ -382,7 +358,7 @@ public class DlsFlsValveImplTest {
         boolean expectedResult,
         Version minNodeVersion,
         String dlsModeHeader,
-        String expectedCompletionMarker,
+        String expectedCompletionHeader,
         boolean hasDlsRestrictions,
         boolean hasFlsRestrictions
     ) throws Exception {
@@ -452,7 +428,9 @@ public class DlsFlsValveImplTest {
         @SuppressWarnings("unchecked")
         ActionListener<Object> listener = mock(ActionListener.class);
         doAnswer(invocation -> {
-            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is(expectedCompletionMarker));
+            if (expectedCompletionHeader != null) {
+                assertThat(threadContext.getHeader(expectedCompletionHeader), is("true"));
+            }
             return null;
         }).when(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
         DlsFlsValveImpl valve = new DlsFlsValveImpl(
@@ -470,6 +448,7 @@ public class DlsFlsValveImplTest {
         boolean result = valve.invoke(context, listener);
 
         assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+        assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED), is((String) null));
         if (expectedResult) {
             assertThat(searchRequest.source().query(), sameInstance(query));
             verify(nodeClient, never()).search(

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -137,9 +137,21 @@ public class DlsFlsValveImplTest {
         assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
     }
 
+    @Test
+    public void legacyHybridQueryDlsMarkerPreventsValveReentry() throws Exception {
+        assertDlsMarkerPreventsValveReentry(
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
+    }
+
     private static void assertDlsMarkerPreventsValveReentry(String header) throws Exception {
+        assertDlsMarkerPreventsValveReentry(header, "true");
+    }
+
+    private static void assertDlsMarkerPreventsValveReentry(String header, String headerValue) throws Exception {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(header, "true");
+        threadContext.putHeader(header, headerValue);
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -137,21 +137,9 @@ public class DlsFlsValveImplTest {
         assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
     }
 
-    @Test
-    public void legacyHybridQueryDlsMarkerPreventsValveReentry() throws Exception {
-        assertDlsMarkerPreventsValveReentry(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
-    }
-
     private static void assertDlsMarkerPreventsValveReentry(String header) throws Exception {
-        assertDlsMarkerPreventsValveReentry(header, "true");
-    }
-
-    private static void assertDlsMarkerPreventsValveReentry(String header, String headerValue) throws Exception {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(header, headerValue);
+        threadContext.putHeader(header, "true");
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);

--- a/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
+++ b/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
@@ -37,6 +37,20 @@ public class DlsFlsBaseContextTest {
     }
 
     @Test
+    public void legacyHybridMarkerRetainsReaderLevelDlsDuringRollingUpgrade() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));
+
+        threadContext.putHeader(
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
+
+        assertThat(context.isDlsQueryFilterApplied(), is(true));
+        assertThat(context.isDlsDoneOnFilterLevel(), is(false));
+    }
+
+    @Test
     public void filterLevelDlsMarkerDoesNotMarkHybridQueryFilterAsApplied() {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));

--- a/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
+++ b/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
@@ -37,20 +37,6 @@ public class DlsFlsBaseContextTest {
     }
 
     @Test
-    public void legacyHybridMarkerRetainsReaderLevelDlsDuringRollingUpgrade() {
-        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));
-
-        threadContext.putHeader(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
-
-        assertThat(context.isDlsQueryFilterApplied(), is(true));
-        assertThat(context.isDlsDoneOnFilterLevel(), is(false));
-    }
-
-    @Test
     public void filterLevelDlsMarkerDoesNotMarkHybridQueryFilterAsApplied() {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));

--- a/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
+++ b/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
@@ -30,10 +30,7 @@ public class DlsFlsBaseContextTest {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));
 
-        threadContext.putHeader(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
+        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
 
         assertThat(context.isDlsQueryFilterApplied(), is(true));
         assertThat(context.isDlsDoneOnFilterLevel(), is(false));

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -487,20 +487,9 @@ public class SecurityInterceptorTests {
 
     @Test
     public void testHybridQueryDlsStateIsCopiedToLocalNodes() {
-        assertHybridQueryDlsStateIsCopiedToLocalNodes(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
-    }
-
-    @Test
-    public void testLegacyHybridQueryDlsStateIsCopiedToLocalNodes() {
-        assertHybridQueryDlsStateIsCopiedToLocalNodes(
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
-    }
-
-    private void assertHybridQueryDlsStateIsCopiedToLocalNodes(String header, String headerValue) {
         enableCrossClusterSearch();
-        threadPool.getThreadContext().putHeader(header, headerValue);
+        String headerValue = "hybrid DLS query filter applied";
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, headerValue);
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(localNode)).thenReturn(true);
         when(clusterInfoHolder.hasNode(otherNode)).thenReturn(true);
@@ -514,7 +503,10 @@ public class SecurityInterceptorTests {
                 TransportRequestOptions options,
                 TransportResponseHandler<T> handler
             ) {
-                assertThat(threadPool.getThreadContext().getHeader(header), is(headerValue));
+                assertThat(
+                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED),
+                    is(headerValue)
+                );
                 senderLatch.get().countDown();
             }
         };
@@ -545,15 +537,6 @@ public class SecurityInterceptorTests {
     }
 
     @Test
-    public void testLegacyHybridQueryDlsStateIsRemovedForNonSearchAction() {
-        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(
-            "internal:hybrid-follow-up",
-            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-        );
-    }
-
-    @Test
     public void testUnrecognizedNonSearchDestinationWithoutHybridMarkerUsesNormalHeaders() {
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
@@ -562,11 +545,7 @@ public class SecurityInterceptorTests {
     }
 
     private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(String action) {
-        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(action, ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
-    }
-
-    private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(String action, String header, String headerValue) {
-        threadPool.getThreadContext().putHeader(header, headerValue);
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
 
@@ -579,7 +558,7 @@ public class SecurityInterceptorTests {
                 TransportRequestOptions options,
                 TransportResponseHandler<T> handler
             ) {
-                assertNull(threadPool.getThreadContext().getHeader(header));
+                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED));
                 senderLatch.get().countDown();
             }
         };

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -487,9 +487,20 @@ public class SecurityInterceptorTests {
 
     @Test
     public void testHybridQueryDlsStateIsCopiedToLocalNodes() {
+        assertHybridQueryDlsStateIsCopiedToLocalNodes(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+    }
+
+    @Test
+    public void testLegacyHybridQueryDlsStateIsCopiedToLocalNodes() {
+        assertHybridQueryDlsStateIsCopiedToLocalNodes(
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
+    }
+
+    private void assertHybridQueryDlsStateIsCopiedToLocalNodes(String header, String headerValue) {
         enableCrossClusterSearch();
-        String headerValue = "hybrid DLS query filter applied";
-        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, headerValue);
+        threadPool.getThreadContext().putHeader(header, headerValue);
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(localNode)).thenReturn(true);
         when(clusterInfoHolder.hasNode(otherNode)).thenReturn(true);
@@ -503,10 +514,7 @@ public class SecurityInterceptorTests {
                 TransportRequestOptions options,
                 TransportResponseHandler<T> handler
             ) {
-                assertThat(
-                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED),
-                    is(headerValue)
-                );
+                assertThat(threadPool.getThreadContext().getHeader(header), is(headerValue));
                 senderLatch.get().countDown();
             }
         };
@@ -537,6 +545,15 @@ public class SecurityInterceptorTests {
     }
 
     @Test
+    public void testLegacyHybridQueryDlsStateIsRemovedForNonSearchAction() {
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(
+            "internal:hybrid-follow-up",
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
+    }
+
+    @Test
     public void testUnrecognizedNonSearchDestinationWithoutHybridMarkerUsesNormalHeaders() {
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
@@ -545,7 +562,11 @@ public class SecurityInterceptorTests {
     }
 
     private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(String action) {
-        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(action, ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+    }
+
+    private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(String action, String header, String headerValue) {
+        threadPool.getThreadContext().putHeader(header, headerValue);
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
 
@@ -558,7 +579,7 @@ public class SecurityInterceptorTests {
                 TransportRequestOptions options,
                 TransportResponseHandler<T> handler
             ) {
-                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED));
+                assertNull(threadPool.getThreadContext().getHeader(header));
                 senderLatch.get().countDown();
             }
         };

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -470,6 +470,8 @@ public class SecurityInterceptorTests {
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER, "fake masked field header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER, "fake doc allowlist header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "fake filter level dls header");
+        threadPool.getThreadContext()
+            .putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "fake dls query filter applied header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER, "fake dls mode header");
         threadPool.getThreadContext()
             .putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER, "fake dls filter header");
@@ -486,8 +488,8 @@ public class SecurityInterceptorTests {
     @Test
     public void testHybridQueryDlsStateIsCopiedToLocalNodes() {
         enableCrossClusterSearch();
-        String headerValue = ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE;
-        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, headerValue);
+        String headerValue = "hybrid DLS query filter applied";
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, headerValue);
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(localNode)).thenReturn(true);
         when(clusterInfoHolder.hasNode(otherNode)).thenReturn(true);
@@ -502,7 +504,7 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 assertThat(
-                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
+                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED),
                     is(headerValue)
                 );
                 senderLatch.get().countDown();
@@ -543,11 +545,7 @@ public class SecurityInterceptorTests {
     }
 
     private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(String action) {
-        threadPool.getThreadContext()
-            .putHeader(
-                ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-                ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
-            );
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
 
@@ -560,7 +558,7 @@ public class SecurityInterceptorTests {
                 TransportRequestOptions options,
                 TransportResponseHandler<T> handler
             ) {
-                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE));
+                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED));
                 senderLatch.get().countDown();
             }
         };


### PR DESCRIPTION
## Summary

- Replace the hybrid DLS sentinel value in the filter-level completion header with a dedicated header.
~~- Continue accepting the legacy sentinel from unpatched nodes during rolling upgrades.~~
- Remove the cluster-wide version gate, allowing safe backports and mixed-version rollout behavior.
- Preserve reader-level DLS and strip both marker formats before dispatch to non-local clusters.

## Security review

No security finding under the mixed patched-node and unpatched-node cluster assumption.

- Untrusted REST callers cannot forge either internal header: security-prefixed headers are rejected at ingress.
- Unpatched coordinator to patched data node: the patched node recognizes the legacy sentinel as hybrid-query-only completion, does not treat it as full filter-level completion, and retains reader-level DLS.
- Patched coordinator to unpatched data node: the unpatched node ignores the unfamiliar dedicated marker and performs normal DLS processing. This can repeat DLS work but is fail-closed.
- Patched nodes preserve both marker formats during local fan-out. If an unpatched intermediate node drops the unfamiliar dedicated marker, downstream nodes fall back to normal DLS rather than bypassing it.
- Cross-cluster dispatch strips both marker formats on patched nodes. Unpatched nodes already strip the legacy sentinel and do not copy the unfamiliar dedicated header.
- Only the exact legacy sentinel is reclassified; the ordinary filter-level completion value continues to suppress reader-level DLS as before.
