### PR TITLE
Harden migrate tests for single-provider (no typeField) resources

### DIFF
--- a/src/test/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiActionTests.java
+++ b/src/test/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiActionTests.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.resources.ResourcePluginInfo;
 
 import tools.jackson.databind.JsonNode;
@@ -23,6 +24,7 @@ import tools.jackson.databind.ObjectMapper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -141,6 +143,57 @@ public class MigrateResourceSharingInfoApiActionTests {
     @Test
     public void jsonPointerPreservesLeadingSlash() {
         assertEquals("/monitor/user/name", MigrateResourceSharingInfoApiAction.jsonPointer("/monitor/user/name"));
+    }
+
+    @Test
+    public void classifyNotificationConfigFallsBackToSingleAccessLevelKey() throws Exception {
+        // A single-provider index with no typeField (e.g. notifications' notification_config) is
+        // classified by the sole default_access_level key, so the doc is migrated rather than skipped.
+        // Uses a faithful `.opensearch-notifications-config` _source (NotificationConfigDoc.toXContent:
+        // metadata + config, no envelope) with the real NotificationConstants tag names.
+        JsonNode notifDoc = mapper.readTree(
+            "{ \"metadata\": { \"last_updated_time_ms\": 1735689600000, \"created_time_ms\": 1735689600000,"
+                + " \"access\": [\"role_a\", \"role_b\"] },"
+                + " \"config\": { \"name\": \"channel-1\", \"config_type\": \"slack\", \"is_enabled\": true } }"
+        );
+        String result = MigrateResourceSharingInfoApiAction.classifyDocType(
+            notifDoc,
+            Collections.emptyList(),
+            Collections.singletonMap("notification_config", "notifications_read_write"),
+            resourcePluginInfo,
+            ".opensearch-notifications-config"
+        );
+        assertEquals("notification_config", result);
+    }
+
+    @Test
+    public void nonResolvingUsernamePathYieldsNoOwnerSoMigrationUsesDefaultOwner() throws Exception {
+        // Notification config docs have no owner name. The migrate call must still pass a valid,
+        // non-empty username_path (an empty "" is rejected by PATH_VALIDATOR#requireNonEmpty), so it
+        // is pointed at a path that does not exist on the doc. It resolves to no value (null) and
+        // createNewSharingRecords falls back to default_owner, while backend_roles_path
+        // "/metadata/access" still yields the legacy access list to share with.
+        JsonNode notifDoc = mapper.readTree(
+            "{ \"metadata\": { \"last_updated_time_ms\": 1735689600000, \"created_time_ms\": 1735689600000,"
+                + " \"access\": [\"role_a\", \"role_b\"] },"
+                + " \"config\": { \"name\": \"channel-1\", \"config_type\": \"slack\", \"is_enabled\": true } }"
+        );
+
+        // An empty username_path is rejected before extraction, so it cannot be used in the doc example.
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> RequestContentValidator.validatePath("username_path", "", RequestContentValidator.MAX_STRING_LENGTH)
+        );
+
+        // A valid, non-resolving path passes validation and yields no owner (-> default_owner).
+        RequestContentValidator.validatePath("username_path", "/metadata/owner", RequestContentValidator.MAX_STRING_LENGTH);
+        String username = notifDoc.at(MigrateResourceSharingInfoApiAction.jsonPointer("/metadata/owner")).asText(null);
+        assertNull(username);
+
+        JsonNode backendRoles = notifDoc.at(MigrateResourceSharingInfoApiAction.jsonPointer("/metadata/access"));
+        assertEquals(2, backendRoles.size());
+        assertEquals("role_a", backendRoles.get(0).asText());
+        assertEquals("role_b", backendRoles.get(1).asText());
     }
 
 }


### PR DESCRIPTION
### Description

Adds regression coverage for the resource-sharing migrate path used by plugins that register a **single `ResourceProvider` with no `typeField`** (for example, notifications' `notification_config`). This behavior currently has no unit coverage; the tests lock it so a future change to `classifyDocType` or the request-path validation can't silently break migration for these plugins.

Two cases:
- **`classifyNotificationConfigFallsBackToSingleAccessLevelKey`** — with no type paths, `classifyDocType` falls back to the sole `default_access_level` key, so a `notification_config` doc is classified (and migrated) rather than recorded under `skippedResources`. Uses a faithful `.opensearch-notifications-config` `_source` (`NotificationConfigDoc.toXContent` shape with the real `NotificationConstants` tag names).
- **`nonResolvingUsernamePathYieldsNoOwnerSoMigrationUsesDefaultOwner`** — `username_path` must be a valid, non-empty path (an empty `""` is rejected by `PATH_VALIDATOR#requireNonEmpty`), and a valid non-resolving path yields no owner, so migration attributes ownership to `default_owner` while `backend_roles_path` (`/metadata/access`) still supplies the shared backend roles.

Test-only; no production change. The live write-path counterpart is already covered by `MigrateApiTests` (a resource with no owner migrates into `resourcesWithDefaultOwner`).

### Testing

`./gradlew test --tests "org.opensearch.security.resources.api.migrate.MigrateResourceSharingInfoApiActionTests"` — 10 passed, 0 failed.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
