### PR TITLE
[3.8] Unblock 3.8 CI: pin jspecify + guard Eclipse JDT formatter provisioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -498,6 +498,7 @@ configurations {
             force "io.netty:netty-transport-native-unix-common:${versions.netty}"
             force "com.github.luben:zstd-jni:${versions.zstd}"
             force libs.google.guava
+            force libs.jspecify
             force libs.lz4.java
             force libs.snappy.java
 

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -1,5 +1,12 @@
 allprojects {
 	project.apply plugin: "com.diffplug.spotless"
+	// The Eclipse JDT formatter is provisioned by Spotless from a P2 update-site mirror during Gradle's
+	// configuration phase. That means every Gradle invocation - including test-only tasks that never format
+	// anything - reaches out to the mirror, which intermittently fails with a SocketTimeoutException (most
+	// often on Windows CI, where the Equo formatter cache under ~/.m2 is not persisted between runs). Only
+	// wire the Eclipse step when a spotless task is actually being run. The dedicated code-hygiene jobs always
+	// invoke spotlessApply/spotlessCheck by name, so formatting enforcement is unchanged.
+	def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
 	spotless {
 		java {
 			// Normally this isn't necessary, but we have Java sources in
@@ -14,7 +21,9 @@ allprojects {
 				'\\#java|\\#org.apache|\\#org.hamcrest|\\#org.opensearch|\\#'
 			)
 			removeUnusedImports()
-			eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+			if (runningSpotlessTask) {
+				eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+			}
 			trimTrailingWhitespace()
 			endWithNewline();
 			custom 'Replace illegal HttpStatus import w/ correct one', {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jaxb                = "2.3.9"
 lz4_java            = "1.11.1"
 snappy_java         = "1.1.10.8"
 guava               = "33.6.0-jre"
+jspecify            = "1.0.1"
 spring_framework    = "7.0.8"
 
 [libraries]
@@ -50,6 +51,7 @@ lz4-java = { group = "at.yawk.lz4", name = "lz4-java", version.ref = "lz4_java" 
 snappy-java = { group = "org.xerial.snappy", name = "snappy-java", version.ref = "snappy_java" }
 
 google-guava = { group = "com.google.guava", name="guava", version.ref = "guava" }
+jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 
 #spring framework
 springframework-core = { group = "org.springframework", name = "spring-core", version.ref = "spring_framework" }

--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -80,6 +80,7 @@ configurations {
             force "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
             force "com.google.protobuf:protobuf-java:${versions.protobuf}"
             force libs.google.guava
+            force libs.jspecify
             force "com.google.guava:failureaccess:1.0.3"
             force "io.projectreactor:reactor-core:3.8.6"
 


### PR DESCRIPTION
### Description

Two `main`-only CI fixes never reached `3.8`, and together they deadlock every `3.8` PR (dependency resolution fails, and the Spotless scan times out fetching the formatter), so neither could be validated in isolation. This PR carries both:

**1. Pin jspecify (resolves `1.0.1` vs `1.0.0` conflict).** `io.projectreactor.netty:reactor-netty-core:1.3.7` pulls `org.jspecify:jspecify:1.0.1` while `com.google.guava:33.6.0-jre` and OpenSearch core pull `1.0.0`; the OpenSearch build plugin's `failOnVersionConflict` fails the build. `main` forces jspecify (added with the guava bump in `2314b027d`); this adds the catalog entry + `force libs.jspecify` on `3.8`. Verified: `integrationTestCompileClasspath` now resolves `1.0.0 -> 1.0.1 (forced)`.

**2. Guard Eclipse JDT formatter provisioning (backport of #6438).** Spotless provisions the JDT formatter from a P2 mirror during Gradle's configuration phase for every task, intermittently failing with `SocketTimeoutException`. Wire the Eclipse step only when a spotless task runs. Cherry-pick of `024622ffb`.

Supersedes the standalone backports #6458 and #6459 (folded here so a single PR has both fixes and can go green).

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.