### PR TITLE
[Backport 3.8] Only provision Eclipse JDT formatter when running a spotless task (#6438)

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -1,5 +1,12 @@
 allprojects {
 	project.apply plugin: "com.diffplug.spotless"
+	// The Eclipse JDT formatter is provisioned by Spotless from a P2 update-site mirror during Gradle's
+	// configuration phase. That means every Gradle invocation - including test-only tasks that never format
+	// anything - reaches out to the mirror, which intermittently fails with a SocketTimeoutException (most
+	// often on Windows CI, where the Equo formatter cache under ~/.m2 is not persisted between runs). Only
+	// wire the Eclipse step when a spotless task is actually being run. The dedicated code-hygiene jobs always
+	// invoke spotlessApply/spotlessCheck by name, so formatting enforcement is unchanged.
+	def runningSpotlessTask = gradle.startParameter.taskNames.any { it.toLowerCase(Locale.ROOT).contains('spotless') }
 	spotless {
 		java {
 			// Normally this isn't necessary, but we have Java sources in
@@ -14,7 +21,9 @@ allprojects {
 				'\\#java|\\#org.apache|\\#org.hamcrest|\\#org.opensearch|\\#'
 			)
 			removeUnusedImports()
-			eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+			if (runningSpotlessTask) {
+				eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+			}
 			trimTrailingWhitespace()
 			endWithNewline();
 			custom 'Replace illegal HttpStatus import w/ correct one', {


### PR DESCRIPTION
### Description

Backports #6438 to `3.8`.

Spotless provisions the Eclipse JDT formatter from a P2 update-site mirror during Gradle's **configuration phase**, so every Gradle invocation — including test-only tasks that never format anything — reaches out to the mirror and can fail with `SocketTimeoutException: timeout` (`Failed to load eclipse jdt formatter`). On `3.8` this surfaces across many CI jobs (build-health, integration/resource/sample-plugin tests, Windows especially).

`main` fixed this in #6438 by wiring the Eclipse step only when a spotless task is actually being run; the dedicated code-hygiene jobs still invoke `spotlessApply`/`spotlessCheck` by name, so formatting enforcement is unchanged. This backports that guard to `3.8`.

Cherry-pick of 024622ffb2a3a1db0d1cfd655018312325ef51e6.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
