### PR TITLE
Restore ML model registration with security

### DIFF
--- a/src/main/java/org/opensearch/security/user/User.java
+++ b/src/main/java/org/opensearch/security/user/User.java
@@ -44,6 +44,7 @@ import java.util.Objects;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.identity.Subject;
@@ -158,6 +159,7 @@ public class User implements Serializable, CustomAttributesAware, Principal, Sub
     }
 
     @Override
+    @JsonIgnore
     public Principal getPrincipal() {
         return this;
     }

--- a/src/test/java/org/opensearch/security/user/UserTests.java
+++ b/src/test/java/org/opensearch/security/user/UserTests.java
@@ -15,6 +15,9 @@ import org.junit.Test;
 
 import org.opensearch.identity.Subject;
 
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
@@ -28,5 +31,17 @@ public class UserTests {
 
         assertThat(subject.getPrincipal(), sameInstance(user));
         assertThat(subject.getPrincipal().getName(), equalTo(user.getName()));
+    }
+
+    @Test
+    public void testUserCanBeSerializedWithJackson3() throws Exception {
+        User user = new User("test-user");
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String userContext = objectMapper.writeValueAsString(user);
+        JsonNode serializedUser = objectMapper.readTree(userContext);
+
+        assertThat(serializedUser.get("name").asText(), equalTo(user.getName()));
+        assertThat(serializedUser.has("principal"), equalTo(false));
     }
 }


### PR DESCRIPTION
## Description

Security User implements both Principal and Subject, with getPrincipal returning the User itself. Jackson 3 consequently discovers a self-referential principal bean property, which prevents ML Commons from serializing the authenticated user context during model registration and deployment.

This change:

- excludes getPrincipal from JSON serialization while preserving the Subject contract;
- restores the User JSON shape from before Subject support was added; and
- adds a Jackson 3 regression test matching the ML Commons serialization flow.

The failure is availability-related: authorization behavior and Principal identity remain unchanged.

Fixes #6433.

## Testing

- ./gradlew test --tests org.opensearch.security.user.UserTests
- ./gradlew spotlessJavaCheck checkstyleMain checkstyleTest