### PR TITLE
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version (security)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.25.0'
+    id 'com.diffplug.spotless' version '8.10.1'
     id 'checkstyle'
     id 'com.netflix.nebula.ospackage' version "11.11.2"
     id "org.gradle.test-retry" version "1.6.5"

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -22,7 +22,7 @@ allprojects {
 			)
 			removeUnusedImports()
 			if (runningSpotlessTask) {
-				eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
+				eclipse('4.29').withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
 			}
 			trimTrailingWhitespace()
 			endWithNewline();


### PR DESCRIPTION
### Description
Guard eclipse() to spotless tasks and keep P2 mirror on pinned version. The guard and mirror already landed in https://github.com/opensearch-project/security/pull/6438; this PR adds the version pin.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
