### PR TITLE
Stabilize parallel test cluster startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,9 @@ opensearch_version = System.getProperty("opensearch.version", "3.8.0-SNAPSHOT")
 - Clean up all resources in `@After` / `@AfterClass` methods.
 - Integration tests must not depend on test-execution order.
 - Use `./gradlew test -Dtests.iters=N` to repeat with varied random seeds when validating stability.
+- Cluster-backed unit tests derive disjoint TCP port bands from Gradle's
+  `org.gradle.test.worker` property (or the legacy `forkno` property). Do not
+  override either property with a shared value when using parallel test forks.
 
 ## Code Style and Static Analysis
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -96,6 +96,7 @@ public class LocalOpenSearchCluster {
     private static final Logger log = LogManager.getLogger(LocalOpenSearchCluster.class);
 
     private final String clusterName;
+    private final String portAllocationClient;
     private final ClusterManager clusterManager;
     private final NodeSettingsSupplier nodeSettingsSupplier;
     private final List<Class<? extends Plugin>> plugins;
@@ -123,6 +124,7 @@ public class LocalOpenSearchCluster {
         Integer expectedNodeStartCount
     ) {
         this.clusterName = clusterName;
+        this.portAllocationClient = clusterName + "_" + Integer.toHexString(System.identityHashCode(this));
         this.clusterManager = clusterManager;
         this.nodeSettingsSupplier = nodeSettingsSupplier;
         this.plugins = plugins;
@@ -158,15 +160,49 @@ public class LocalOpenSearchCluster {
     public void start() throws Exception {
         log.info("Starting {}", clusterName);
 
+        try {
+            boolean portCollision;
+            do {
+                try (PortAllocator.PortAllocationLock ignored = PortAllocator.acquireExclusivePortAllocationLock()) {
+                    startNodesWithExclusivePortAllocation();
+                }
+
+                portCollision = isNodeFailedWithPortCollision();
+                if (portCollision) {
+                    log.info("Detected port collision for cluster manager node. Retrying.");
+                    retry();
+                }
+            } while (portCollision);
+
+            log.info("Startup finished. Waiting for GREEN");
+
+            int expectedCount = nodes.size();
+            if (expectedNodeStartupCount != null) {
+                expectedCount = expectedNodeStartupCount;
+            }
+
+            waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), expectedCount);
+            log.info("Started: {}", this);
+        } catch (Exception e) {
+            cleanupAfterFailedStart(e);
+            throw e;
+        }
+    }
+
+    private void startNodesWithExclusivePortAllocation() {
         int clusterManagerNodeCount = clusterManager.getClusterManagerNodes();
         int nonClusterManagerNodeCount = clusterManager.getDataNodes() + clusterManager.getClientNodes();
 
         SortedSet<Integer> clusterManagerNodeTransportPorts = TCP.allocate(
-            clusterName,
+            portAllocationClient,
             Math.max(clusterManagerNodeCount, 4),
             5000 + 42 * 1000 + 300
         );
-        SortedSet<Integer> clusterManagerNodeHttpPorts = TCP.allocate(clusterName, clusterManagerNodeCount, 5000 + 42 * 1000 + 200);
+        SortedSet<Integer> clusterManagerNodeHttpPorts = TCP.allocate(
+            portAllocationClient,
+            clusterManagerNodeCount,
+            5000 + 42 * 1000 + 200
+        );
 
         this.seedHosts = toHostList(clusterManagerNodeTransportPorts);
         Set<Integer> clusterManagerPorts = clusterManagerNodeTransportPorts.stream()
@@ -184,11 +220,15 @@ public class LocalOpenSearchCluster {
         );
 
         SortedSet<Integer> nonClusterManagerNodeTransportPorts = TCP.allocate(
-            clusterName,
+            portAllocationClient,
             nonClusterManagerNodeCount,
             5000 + 42 * 1000 + 310
         );
-        SortedSet<Integer> nonClusterManagerNodeHttpPorts = TCP.allocate(clusterName, nonClusterManagerNodeCount, 5000 + 42 * 1000 + 210);
+        SortedSet<Integer> nonClusterManagerNodeHttpPorts = TCP.allocate(
+            portAllocationClient,
+            nonClusterManagerNodeCount,
+            5000 + 42 * 1000 + 210
+        );
 
         CompletableFuture<Void> nonClusterManagerNodeFuture = startNodes(
             nodeCounter,
@@ -198,24 +238,6 @@ public class LocalOpenSearchCluster {
         );
 
         CompletableFuture.allOf(clusterManagerNodeFuture, nonClusterManagerNodeFuture).join();
-
-        if (isNodeFailedWithPortCollision()) {
-            log.info("Detected port collision for cluster manager node. Retrying.");
-
-            retry();
-            return;
-        }
-
-        log.info("Startup finished. Waiting for GREEN");
-
-        int expectedCount = nodes.size();
-        if (expectedNodeStartupCount != null) {
-            expectedCount = expectedNodeStartupCount;
-        }
-
-        waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), expectedCount);
-        log.info("Started: {}", this);
-
     }
 
     public String getClusterName() {
@@ -229,9 +251,13 @@ public class LocalOpenSearchCluster {
     public void stop() {
         List<CompletableFuture<Boolean>> stopFutures = new ArrayList<>();
         for (Node node : nodes) {
-            stopFutures.add(node.stop(2, TimeUnit.SECONDS));
+            stopFutures.add(node.stop(10, TimeUnit.SECONDS));
         }
-        CompletableFuture.allOf(stopFutures.toArray(CompletableFuture[]::new)).join();
+        try {
+            CompletableFuture.allOf(stopFutures.toArray(CompletableFuture[]::new)).join();
+        } finally {
+            TCP.release(portAllocationClient);
+        }
     }
 
     public void destroy() {
@@ -287,7 +313,16 @@ public class LocalOpenSearchCluster {
         this.seedHosts = null;
         this.initialClusterManagerHosts = null;
         createClusterDirectory("local_cluster_" + clusterName + "_retry_" + retry);
-        start();
+    }
+
+    private void cleanupAfterFailedStart(Exception originalException) {
+        try {
+            stop();
+        } catch (RuntimeException cleanupException) {
+            originalException.addSuppressed(cleanupException);
+        } finally {
+            nodes.clear();
+        }
     }
 
     @SafeVarargs
@@ -497,7 +532,13 @@ public class LocalOpenSearchCluster {
                         portCollision = true;
                         try {
                             node.close();
-                        } catch (IOException e1) {
+                            if (!node.awaitClose(10, TimeUnit.SECONDS)) {
+                                log.warn("Timed out while closing {} after a port collision", this);
+                            }
+                        } catch (IOException | InterruptedException e1) {
+                            if (e1 instanceof InterruptedException) {
+                                Thread.currentThread().interrupt();
+                            }
                             log.error(e1);
                         }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocator.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocator.java
@@ -113,7 +113,7 @@ public class PortAllocator {
     public synchronized void reserve(int... ports) {
 
         for (int port : ports) {
-            allocate("reserved", port);
+            allocatedPorts.put(port, new AllocatedPort("reserved"));
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocator.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocator.java
@@ -28,12 +28,19 @@
 
 package org.opensearch.test.framework.cluster;
 
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.opensearch.test.framework.cluster.SocketUtils.SocketType;
 
@@ -50,6 +57,9 @@ public class PortAllocator {
     public static final PortAllocator TCP = new PortAllocator(SocketType.TCP, Duration.ofSeconds(100));
     public static final PortAllocator UDP = new PortAllocator(SocketType.UDP, Duration.ofSeconds(100));
 
+    private static final String PORT_ALLOCATION_LOCK_FILE = "opensearch-security-test-ports.lock";
+    private static final ReentrantLock localPortAllocationLock = new ReentrantLock();
+
     private final SocketType socketType;
     private final Duration timeoutDuration;
     private final Map<Integer, AllocatedPort> allocatedPorts = new HashMap<>();
@@ -59,7 +69,7 @@ public class PortAllocator {
         this.timeoutDuration = timeoutDuration;
     }
 
-    public SortedSet<Integer> allocate(String clientName, int numRequested, int minPort) {
+    public synchronized SortedSet<Integer> allocate(String clientName, int numRequested, int minPort) {
 
         int startPort = minPort;
 
@@ -86,7 +96,7 @@ public class PortAllocator {
         return foundPorts;
     }
 
-    public int allocateSingle(String clientName, int minPort) {
+    public synchronized int allocateSingle(String clientName, int minPort) {
 
         int startPort = minPort;
 
@@ -100,11 +110,47 @@ public class PortAllocator {
 
     }
 
-    public void reserve(int... ports) {
+    public synchronized void reserve(int... ports) {
 
         for (int port : ports) {
             allocate("reserved", port);
         }
+    }
+
+    /**
+    * Serializes the allocation-to-bind window across Gradle test workers and separate local Gradle invocations.
+    *
+    * A port cannot remain reserved after it is handed to an OpenSearch node, so a socket probe alone has an
+    * unavoidable time-of-check/time-of-use race. Hold this lock from allocation until every node has bound its
+    * transport and HTTP ports. The operating system releases the file lock when a test JVM exits unexpectedly.
+    */
+    public static PortAllocationLock acquireExclusivePortAllocationLock() throws IOException, InterruptedException {
+        localPortAllocationLock.lockInterruptibly();
+        FileChannel channel = null;
+
+        try {
+            Path lockFile = Paths.get(System.getProperty("java.io.tmpdir"), PORT_ALLOCATION_LOCK_FILE);
+            channel = FileChannel.open(lockFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            return new PortAllocationLock(channel, channel.lock());
+        } catch (IOException | RuntimeException e) {
+            if (channel != null) {
+                try {
+                    channel.close();
+                } catch (IOException closeException) {
+                    e.addSuppressed(closeException);
+                }
+            }
+            localPortAllocationLock.unlock();
+            throw e;
+        }
+    }
+
+    /**
+    * Releases all ports allocated for a stopped cluster. Collision reservations are deliberately retained until
+    * their timeout so an immediate retry does not choose the same port again.
+    */
+    public synchronized void release(String clientName) {
+        allocatedPorts.entrySet().removeIf(entry -> clientName.equals(entry.getValue().client));
     }
 
     private boolean isInUse(int port) {
@@ -171,6 +217,35 @@ public class PortAllocator {
         @Override
         public String toString() {
             return "AllocatedPort [client=" + client + ", allocatedAt=" + allocatedAt + "]";
+        }
+    }
+
+    public static final class PortAllocationLock implements AutoCloseable {
+        private final FileChannel channel;
+        private final FileLock lock;
+        private boolean closed;
+
+        private PortAllocationLock(FileChannel channel, FileLock lock) {
+            this.channel = channel;
+            this.lock = lock;
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
+            try {
+                lock.release();
+            } finally {
+                try {
+                    channel.close();
+                } finally {
+                    localPortAllocationLock.unlock();
+                }
+            }
         }
     }
 }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocatorTests.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocatorTests.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -30,6 +31,17 @@ public class PortAllocatorTests {
         allocator.release("first-cluster");
 
         assertThat(allocator.allocateSingle("second-cluster", allocatedPort), is(allocatedPort));
+    }
+
+    @Test
+    public void retainsCollisionReservationsWhenClusterPortsAreReleased() {
+        PortAllocator allocator = new PortAllocator(SocketUtils.SocketType.TCP, Duration.ofMinutes(1));
+        int collisionPort = allocator.allocateSingle("first-cluster", 50000);
+
+        allocator.reserve(collisionPort);
+        allocator.release("first-cluster");
+
+        assertThat(allocator.allocateSingle("second-cluster", collisionPort), is(not(collisionPort)));
     }
 
     @Test

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocatorTests.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/PortAllocatorTests.java
@@ -1,0 +1,60 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+package org.opensearch.test.framework.cluster;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.SortedSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PortAllocatorTests {
+
+    @Test
+    public void releasesPortsAllocatedForStoppedCluster() {
+        PortAllocator allocator = new PortAllocator(SocketUtils.SocketType.TCP, Duration.ofMinutes(1));
+        SortedSet<Integer> firstAllocation = allocator.allocate("first-cluster", 1, 50000);
+        int allocatedPort = firstAllocation.first();
+
+        allocator.release("first-cluster");
+
+        assertThat(allocator.allocateSingle("second-cluster", allocatedPort), is(allocatedPort));
+    }
+
+    @Test
+    public void serializesPortAllocationWithinTestJvm() throws Exception {
+        CountDownLatch contenderStarted = new CountDownLatch(1);
+        CountDownLatch contenderAcquiredLock = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try (PortAllocator.PortAllocationLock ignored = PortAllocator.acquireExclusivePortAllocationLock()) {
+            executor.submit(() -> {
+                contenderStarted.countDown();
+                try (PortAllocator.PortAllocationLock contenderLock = PortAllocator.acquireExclusivePortAllocationLock()) {
+                    contenderAcquiredLock.countDown();
+                } catch (IOException | InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            assertTrue(contenderStarted.await(5, TimeUnit.SECONDS));
+            assertFalse(contenderAcquiredLock.await(1, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+
+        assertTrue(contenderAcquiredLock.await(5, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -42,6 +42,8 @@ import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -75,6 +77,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public final class ClusterHelper {
+
+    private static final int PORT_RANGE_SIZE = 5000;
+    private static final int PORT_RANGE_COUNT = (SocketUtils.PORT_RANGE_MAX - SocketUtils.PORT_RANGE_MIN + 1) / PORT_RANGE_SIZE;
+    private static final Pattern WORKER_NUMBER = Pattern.compile("(\\d+)$");
 
     static {
         resetSystemProperties();
@@ -147,15 +153,9 @@ public final class ClusterHelper {
 
         List<NodeSettings> internalNodeSettings = clusterConfiguration.getNodeSettings();
 
-        final String forkno = System.getProperty("forkno");
-        int forkNumber = 1;
-
-        if (forkno != null && forkno.length() > 0) {
-            forkNumber = Integer.parseInt(forkno.split("_")[1]);
-        }
-
-        final int min = SocketUtils.PORT_RANGE_MIN + (forkNumber * 5000);
-        final int max = SocketUtils.PORT_RANGE_MIN + ((forkNumber + 1) * 5000) - 1;
+        final int forkNumber = getPortRangeNumber(System.getProperty("forkno"), System.getProperty("org.gradle.test.worker"));
+        final int min = SocketUtils.PORT_RANGE_MIN + (forkNumber * PORT_RANGE_SIZE);
+        final int max = SocketUtils.PORT_RANGE_MIN + ((forkNumber + 1) * PORT_RANGE_SIZE) - 1;
 
         final SortedSet<Integer> freePorts = SocketUtils.findAvailableTcpPorts(internalNodeSettings.size() * 2, min, max);
         assert freePorts.size() == internalNodeSettings.size() * 2;
@@ -181,7 +181,7 @@ public final class ClusterHelper {
                 + min
                 + "-"
                 + max
-                + ") fork "
+                + ") test worker "
                 + forkNumber
         );
 
@@ -331,21 +331,76 @@ public final class ClusterHelper {
     }
 
     private void closeAllNodes() throws Exception {
+        RuntimeException closeFailure = null;
+
         // close non cluster manager nodes
-        opensearchNodes.stream().filter(n -> !n.isClusterManagerEligible()).forEach(ClusterHelper::closeNode);
+        closeFailure = closeNodes(false, closeFailure);
 
         // close cluster manager nodes
-        opensearchNodes.stream().filter(n -> n.isClusterManagerEligible()).forEach(ClusterHelper::closeNode);
+        closeFailure = closeNodes(true, closeFailure);
         opensearchNodes.clear();
         clusterState = ClusterState.STOPPED;
+
+        if (closeFailure != null) {
+            throw closeFailure;
+        }
+    }
+
+    private RuntimeException closeNodes(boolean clusterManagerNode, RuntimeException closeFailure) {
+        for (PluginAwareNode node : opensearchNodes) {
+            if (node.isClusterManagerEligible() == clusterManagerNode) {
+                try {
+                    closeNode(node);
+                } catch (RuntimeException e) {
+                    if (closeFailure == null) {
+                        closeFailure = e;
+                    } else {
+                        closeFailure.addSuppressed(e);
+                    }
+                }
+            }
+        }
+
+        return closeFailure;
     }
 
     private static void closeNode(Node node) {
         try {
             node.close();
-            node.awaitClose(5, TimeUnit.SECONDS);
-        } catch (Throwable e) {
-            // ignore
+            if (!node.awaitClose(30, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out while stopping node " + node);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while stopping node " + node, e);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to stop node " + node, e);
+        }
+    }
+
+    static int getPortRangeNumber(String forkno, String gradleTestWorker) {
+        Integer workerNumber = getWorkerNumber(forkno);
+        if (workerNumber == null) {
+            workerNumber = getWorkerNumber(gradleTestWorker);
+        }
+
+        return workerNumber == null ? 1 : Math.floorMod(workerNumber, PORT_RANGE_COUNT);
+    }
+
+    private static Integer getWorkerNumber(String workerId) {
+        if (workerId == null || workerId.isBlank()) {
+            return null;
+        }
+
+        Matcher matcher = WORKER_NUMBER.matcher(workerId);
+        if (!matcher.find()) {
+            return null;
+        }
+
+        try {
+            return Integer.parseInt(matcher.group(1));
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelperTests.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelperTests.java
@@ -1,0 +1,33 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+package org.opensearch.security.test.helper.cluster;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ClusterHelperTests {
+
+    @Test
+    public void usesLegacyForkNumberWhenPresent() {
+        assertThat(ClusterHelper.getPortRangeNumber("test_3", "8"), is(3));
+    }
+
+    @Test
+    public void usesGradleWorkerWhenLegacyForkNumberIsMissing() {
+        assertThat(ClusterHelper.getPortRangeNumber(null, "8"), is(8));
+    }
+
+    @Test
+    public void keepsPortRangeWithinAvailablePortSpace() {
+        assertThat(ClusterHelper.getPortRangeNumber(null, "1000"), is(4));
+    }
+
+    @Test
+    public void fallsBackToGradleWorkerForUnrecognisedLegacyForkId() {
+        assertThat(ClusterHelper.getPortRangeNumber("not-a-worker", "4"), is(4));
+    }
+}


### PR DESCRIPTION
### Description

This test fix stabilizes local OpenSearch cluster startup when cluster-backed tests run concurrently.

* Category: Test fix
* Parallel workers and separate test JVMs can select the same apparently free TCP ports during the allocation-to-bind window.
* Previously, allocation was only coordinated inside one JVM, legacy unit-test clusters could share a default port band, collision cleanup did not wait for nodes to close, and stopped-cluster reservations were retained indiscriminately. The new behavior derives worker-specific port bands, serializes allocation through node binding, waits for shutdown during retry and cleanup, releases stopped-cluster ports, and preserves known collision reservations for the retry timeout.

### Issues Resolved

Fixes #6464

This is not a backport.

No new permissions are introduced.

### Testing

* `./gradlew :integrationTest --tests org.opensearch.test.framework.cluster.PortAllocatorTests -x :opensearch-sample-resource-plugin:integrationTest`
* `./gradlew :test --tests org.opensearch.security.test.helper.cluster.ClusterHelperTests -x :opensearch-sample-resource-plugin:test`
* `./gradlew spotlessJavaCheck`
* `./gradlew :precommit -x :opensearch-sample-resource-plugin:precommit`

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR (not applicable; no roles or permissions changed)
- [x] API changes companion pull request created (not applicable; no public API changed)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
