### PR TITLE
Stabilize resource test client load

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/ResourceFocusedTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ResourceFocusedTests.java
@@ -48,6 +48,7 @@ import org.opensearch.transport.client.Client;
 
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.ReferenceCountUtil;
 import reactor.netty.http.HttpProtocol;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -171,9 +172,13 @@ public class ResourceFocusedTests {
             }
 
             final Collection<FullHttpResponse> responses = client.post(requestUris, parallelism);
-            responses.stream()
-                .map(FullHttpResponse::status)
-                .forEach(responseCode -> assertThat(responseCode, equalTo(HttpResponseStatus.UNAUTHORIZED)));
+            try {
+                responses.stream()
+                    .map(FullHttpResponse::status)
+                    .forEach(responseCode -> assertThat(responseCode, equalTo(HttpResponseStatus.UNAUTHORIZED)));
+            } finally {
+                responses.forEach(ReferenceCountUtil::release);
+            }
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/OpenSearchClientProvider.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/OpenSearchClientProvider.java
@@ -234,7 +234,7 @@ public interface OpenSearchClientProvider {
      * Returns a generic HTTP/1.1/HTTP 2.0/HTTP 3.0 client.
      */
     default ReactorHttpClient getGenericClient(HttpProtocol protocol, boolean secure, Settings settings) {
-        return new ReactorHttpClient(true, true, settings, getHttpAddress());
+        return new ReactorHttpClient(protocol, true, secure, settings, getHttpAddress());
     }
 
     default TestRestClient getRestClient(Header... headers) {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClient.java
@@ -16,13 +16,11 @@ package org.opensearch.test.framework.cluster;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.http.netty4.http3.Http3Utils;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -43,32 +41,34 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.ParallelFlux;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.Http2SslContextSpec;
 import reactor.netty.http.Http3SslContextSpec;
 import reactor.netty.http.HttpProtocol;
 import reactor.netty.http.client.HttpClient;
 
-import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_HTTP3_ENABLED;
 import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH;
 
 /**
  * Tiny helper to send http requests over netty.
  */
 public class ReactorHttpClient implements Closeable {
-    private static final java.util.Random RAND = new java.util.Random();
-
     private final boolean compression;
     private final boolean secure;
     private final HttpProtocol protocol;
     private final Settings settings;
     private final InetSocketAddress remoteAddress;
 
-    public ReactorHttpClient(boolean compression, boolean secure, Settings settings, InetSocketAddress remoteAddress) {
+    public ReactorHttpClient(
+        HttpProtocol protocol,
+        boolean compression,
+        boolean secure,
+        Settings settings,
+        InetSocketAddress remoteAddress
+    ) {
         this.compression = compression;
         this.secure = secure;
-        this.protocol = randomProtocol(secure, settings);
+        this.protocol = protocol;
         this.settings = settings;
         this.remoteAddress = remoteAddress;
     }
@@ -83,9 +83,7 @@ public class ReactorHttpClient implements Closeable {
         List<Tuple<String, byte[]>> urisAndBodies,
         int parallelism
     ) {
-        List<FullHttpRequest> requests = new ArrayList<>(urisAndBodies.size());
-        for (int i = 0; i < urisAndBodies.size(); ++i) {
-            final Tuple<String, byte[]> uriAndBody = urisAndBodies.get(i);
+        return sendRequests(remoteAddress, urisAndBodies.stream().map(uriAndBody -> {
             ByteBuf content = Unpooled.copiedBuffer(uriAndBody.v2());
             FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uriAndBody.v1(), content);
             request.headers().add(HttpHeaderNames.HOST, "localhost");
@@ -93,9 +91,8 @@ public class ReactorHttpClient implements Closeable {
             request.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/json");
             request.headers().add(HttpHeaderNames.CONTENT_ENCODING, "gzip");
             request.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), secure ? "https" : "http");
-            requests.add(request);
-        }
-        return sendRequests(remoteAddress, requests, false, parallelism);
+            return request;
+        }).toList(), false, parallelism);
     }
 
     private List<FullHttpResponse> sendRequests(
@@ -104,12 +101,14 @@ public class ReactorHttpClient implements Closeable {
         boolean ordered,
         int parallelism
     ) {
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be greater than zero");
+        }
         final EventLoopGroup eventLoopGroup = new MultiThreadIoEventLoopGroup(parallelism, NioIoHandler.newFactory());
         try {
             final HttpClient client = createClient(remoteAddress, eventLoopGroup);
 
-            @SuppressWarnings("unchecked")
-            final Mono<FullHttpResponse>[] monos = requests.stream()
+            final Flux<Mono<FullHttpResponse>> responses = Flux.fromIterable(requests)
                 .map(
                     request -> client.headers(h -> h.add(request.headers()))
                         .baseUrl(request.uri())
@@ -127,13 +126,12 @@ public class ReactorHttpClient implements Closeable {
                                     )
                                 )
                         )
-                )
-                .toArray(Mono[]::new);
+                );
 
             if (ordered == false) {
-                return ParallelFlux.from(monos).sequential().collectList().block();
+                return responses.flatMap(response -> response, parallelism).collectList().block(Duration.ofMinutes(2));
             } else {
-                return Flux.concat(monos).flatMapSequential(r -> Mono.just(r)).collectList().block(Duration.ofMinutes(2));
+                return responses.concatMap(response -> response).collectList().block(Duration.ofMinutes(2));
             }
         } finally {
             eventLoopGroup.shutdownGracefully().awaitUninterruptibly();
@@ -196,22 +194,6 @@ public class ReactorHttpClient implements Closeable {
 
     public HttpProtocol protocol() {
         return protocol;
-    }
-
-    private static HttpProtocol randomProtocol(boolean secure, Settings settings) {
-        HttpProtocol[] values = null;
-
-        if (secure) {
-            if (Http3Utils.isHttp3Available() && SETTING_HTTP_HTTP3_ENABLED.get(settings).booleanValue() == true) {
-                values = new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2, HttpProtocol.HTTP3 };
-            } else {
-                values = new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2 };
-            }
-        } else {
-            values = new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2C };
-        }
-
-        return values[RAND.nextInt(values.length - 1)];
     }
 
 }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClient.java
@@ -39,6 +39,7 @@ import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.util.ReferenceCountUtil;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.Http11SslContextSpec;
@@ -66,6 +67,7 @@ public class ReactorHttpClient implements Closeable {
         Settings settings,
         InetSocketAddress remoteAddress
     ) {
+        validateProtocol(protocol, secure);
         this.compression = compression;
         this.secure = secure;
         this.protocol = protocol;
@@ -128,13 +130,30 @@ public class ReactorHttpClient implements Closeable {
                         )
                 );
 
-            if (ordered == false) {
-                return responses.flatMap(response -> response, parallelism).collectList().block(Duration.ofMinutes(2));
-            } else {
-                return responses.concatMap(response -> response).collectList().block(Duration.ofMinutes(2));
-            }
+            return collectResponses(responses, ordered, parallelism);
         } finally {
             eventLoopGroup.shutdownGracefully().awaitUninterruptibly();
+        }
+    }
+
+    static List<FullHttpResponse> collectResponses(Flux<Mono<FullHttpResponse>> responses, boolean ordered, int parallelism) {
+        Flux<FullHttpResponse> responseFlux = ordered
+            ? responses.concatMap(response -> response)
+            : responses.flatMap(response -> response, parallelism);
+
+        return responseFlux.collectList().doOnDiscard(FullHttpResponse.class, ReferenceCountUtil::release).block(Duration.ofMinutes(2));
+    }
+
+    private static void validateProtocol(HttpProtocol protocol, boolean secure) {
+        if (protocol == null) {
+            throw new IllegalArgumentException("protocol must not be null");
+        }
+
+        boolean supported = secure
+            ? protocol == HttpProtocol.HTTP11 || protocol == HttpProtocol.H2 || protocol == HttpProtocol.HTTP3
+            : protocol == HttpProtocol.HTTP11 || protocol == HttpProtocol.H2C;
+        if (supported == false) {
+            throw new IllegalArgumentException("Protocol " + protocol + " is not compatible with secure=" + secure);
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClientTests.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClientTests.java
@@ -17,7 +17,12 @@ import org.junit.Test;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.DisposableServer;
 import reactor.netty.http.HttpProtocol;
@@ -26,6 +31,7 @@ import reactor.netty.http.server.HttpServer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThrows;
 
 public class ReactorHttpClientTests {
     @Test
@@ -41,6 +47,38 @@ public class ReactorHttpClientTests {
         ) {
             assertThat(client.protocol(), equalTo(HttpProtocol.HTTP3));
         }
+    }
+
+    @Test
+    public void rejectsProtocolsThatAreIncompatibleWithTransportSecurity() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new ReactorHttpClient(HttpProtocol.H2C, true, true, Settings.EMPTY, InetSocketAddress.createUnresolved("localhost", 443))
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new ReactorHttpClient(
+                HttpProtocol.HTTP3,
+                true,
+                false,
+                Settings.EMPTY,
+                InetSocketAddress.createUnresolved("localhost", 80)
+            )
+        );
+    }
+
+    @Test
+    public void releasesCollectedResponsesWhenARequestFails() {
+        FullHttpResponse response = new DefaultFullHttpResponse(
+            HttpVersion.HTTP_1_1,
+            HttpResponseStatus.OK,
+            Unpooled.buffer(1).writeByte(1)
+        );
+        Flux<Mono<FullHttpResponse>> responses = Flux.just(Mono.just(response), Mono.error(new IllegalStateException("simulated")));
+
+        assertThrows(IllegalStateException.class, () -> ReactorHttpClient.collectResponses(responses, true, 1));
+
+        assertThat(response.refCnt(), equalTo(0));
     }
 
     @Test

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClientTests.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClientTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.opensearch.test.framework.cluster;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import reactor.core.publisher.Mono;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.server.HttpServer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class ReactorHttpClientTests {
+    @Test
+    public void honorsRequestedProtocol() {
+        try (
+            ReactorHttpClient client = new ReactorHttpClient(
+                HttpProtocol.HTTP3,
+                true,
+                true,
+                Settings.EMPTY,
+                InetSocketAddress.createUnresolved("localhost", 443)
+            )
+        ) {
+            assertThat(client.protocol(), equalTo(HttpProtocol.HTTP3));
+        }
+    }
+
+    @Test
+    public void limitsConcurrentRequests() {
+        AtomicInteger activeRequests = new AtomicInteger();
+        AtomicInteger maxActiveRequests = new AtomicInteger();
+        DisposableServer server = HttpServer.create().port(0).handle((request, response) -> {
+            int active = activeRequests.incrementAndGet();
+            maxActiveRequests.accumulateAndGet(active, Math::max);
+            return Mono.delay(Duration.ofMillis(20))
+                .then(response.status(HttpResponseStatus.UNAUTHORIZED).send())
+                .doFinally(signalType -> activeRequests.decrementAndGet());
+        }).bindNow();
+
+        try (
+            ReactorHttpClient client = new ReactorHttpClient(
+                HttpProtocol.HTTP11,
+                true,
+                false,
+                Settings.EMPTY,
+                new InetSocketAddress("localhost", server.port())
+            )
+        ) {
+            List<Tuple<String, byte[]>> requests = IntStream.range(0, 20).mapToObj(i -> Tuple.tuple("/", new byte[0])).toList();
+
+            client.post(requests, 2).forEach(response -> {
+                assertThat(response.status(), equalTo(HttpResponseStatus.UNAUTHORIZED));
+                response.release();
+            });
+        } finally {
+            server.disposeNow();
+        }
+
+        assertThat(maxActiveRequests.get(), lessThanOrEqualTo(2));
+    }
+}


### PR DESCRIPTION
### Description

This test fix makes the Reactor Netty client used by resource-focused tests honor its configuration and bound its resource usage.

* Category: Test fix
* The client ignored the requested HTTP protocol, did not cap in-flight requests to the supplied parallelism, and left retained response buffers for callers to manage without exceptional-path cleanup.
* Previously, HTTP/3-focused tests could run over a different protocol and large request batches could be subscribed all at once. The new behavior honors and validates the requested protocol, limits concurrent subscriptions, applies a bounded wait, and releases reference-counted responses on success and exceptional termination.

### Issues Resolved

Fixes #6465

This is not a backport.

No new permissions are introduced.

### Testing

* `./gradlew :integrationTest --tests org.opensearch.test.framework.cluster.ReactorHttpClientTests -x :opensearch-sample-resource-plugin:integrationTest`
* `./gradlew :integrationTest --tests org.opensearch.security.ResourceFocusedTests -x :opensearch-sample-resource-plugin:integrationTest`
* `./gradlew spotlessJavaCheck`
* `./gradlew :precommit -x :opensearch-sample-resource-plugin:precommit`

The full aggregate precommit task was also attempted. It reaches pre-existing forbidden-API violations for `URL.openStream()` in the unchanged sample resource plugin; the root precommit suite above passes.

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented (test behavior is covered by code and regression tests)
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR (not applicable; no roles or permissions changed)
- [x] API changes companion pull request created (not applicable; no public API changed)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
