### PR TITLE
 Add missing index actions to `ppl_full_access` role

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -179,6 +179,10 @@ ppl_full_access:
         - '*'
       allowed_actions:
         - 'indices:admin/mappings/get'
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read/field_caps*'
+        - 'indices:data/read/point_in_time/create'
+        - 'indices:data/read/point_in_time/delete'
         - 'indices:data/read/search*'
         - 'indices:monitor/settings/get'
 


### PR DESCRIPTION
### Description

`ppl_full_access` cannot run a PPL query that pages through a point-in-time context. PIT creation is denied outright, and the `_field_caps` / `resolve/index` probes the SQL plugin issues just before it are denied silently, so nothing in the response points at permissions. All four added actions are read-only or scoped to contexts the role opens itself, over index patterns it can already search.

| Action | Why PPL needs it |
| --- | --- |
| `indices:data/read/point_in_time/create` | Opens a PIT to page result sets past `max_result_window`. |
| `indices:data/read/point_in_time/delete` | Closes that PIT when the cursor is exhausted. |
| `indices:admin/resolve/index` | Resolves the query's index expression to spot aliases and data streams. |
| `indices:data/read/field_caps*` | Asks which matched indices can satisfy the query's time range, to skip opening a PIT on the rest. `*` is required: the per-index `field_caps[index]` sub-action, if denied, yields `"indices": []` with no error. |

### Issues Resolved
Resolves #6448

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR. - **No**

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here. - **No**

### Testing

Local cluster via `./gradlew run` with `opensearch-security`, `opensearch-sql` and `opensearch-job-scheduler` (all 3.9.0.0-SNAPSHOT), running a paginated PPL query over three time-bucketed indices. Baseline is a role replicating `ppl_full_access` as it is on `main`; fixed is the reserved role as shipped in this PR.

| # | Role | SQL-side probes | PPL response |
| --- | --- | --- | --- |
| 1 | baseline | disabled | **500** `no permissions for [indices:data/read/point_in_time/create]` |
| 2 | baseline | enabled | **500** identical to row 1 — the earlier `indices:admin/resolve/index` denial is caught by the SQL plugin and only logged as a `WARN`, so it never reaches the client |
| 3 | fixed | disabled | **200** correct rows |
| 4 | fixed | enabled | **200** correct rows, no denials in the node log |

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
