### PR TITLE
Retry API token loading during startup

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2789,7 +2789,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         if (!SSLConfig.isSslOnlyMode() && !client && !disabled && !useClusterStateToInitSecurityConfig(settings)) {
             cr.initOnNodeStart();
             if (apiTokenRepository != null) {
-                apiTokenRepository.reloadApiTokensFromIndex(
+                apiTokenRepository.reloadApiTokensOnNodeStart(
                     ActionListener.wrap(
                         unused -> log.debug("API tokens loaded on node start"),
                         e -> log.warn("Failed to load API tokens on node start", e)

--- a/src/main/java/org/opensearch/security/action/apitokens/ApiTokenRepository.java
+++ b/src/main/java/org/opensearch/security/action/apitokens/ApiTokenRepository.java
@@ -29,21 +29,27 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.cluster.block.ClusterBlockException;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.discovery.ClusterManagerNotDiscoveredException;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.security.configuration.TokenListener;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.user.User;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 import static org.opensearch.security.http.ApiTokenAuthenticator.API_TOKEN_USER_PREFIX;
 
 public class ApiTokenRepository {
     public static final String TOKEN_PREFIX = "os_";
+    private static final TimeValue STARTUP_RELOAD_RETRY_DELAY = TimeValue.timeValueSeconds(1);
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final ApiTokenIndexHandler apiTokenIndexHandler;
+    private final ThreadPool threadPool;
     private final List<TokenListener> tokenListener = new ArrayList<>();
     private static final Logger log = LogManager.getLogger(ApiTokenRepository.class);
 
@@ -101,6 +107,26 @@ public class ApiTokenRepository {
                 listener.onFailure(new OpenSearchSecurityException("Received error while reloading API tokens metadata from index", e));
             }
         });
+    }
+
+    public void reloadApiTokensOnNodeStart(ActionListener<Void> listener) {
+        reloadApiTokensFromIndex(ActionListener.wrap(listener::onResponse, e -> {
+            boolean retryable = ExceptionsHelper.unwrapCausesAndSuppressed(
+                e,
+                cause -> (cause instanceof ClusterBlockException clusterBlockException && clusterBlockException.retryable())
+                    || cause instanceof ClusterManagerNotDiscoveredException
+            ).isPresent();
+            if (retryable) {
+                log.debug("Cluster is not ready to load API tokens; retrying in {}", STARTUP_RELOAD_RETRY_DELAY);
+                threadPool.scheduleUnlessShuttingDown(
+                    STARTUP_RELOAD_RETRY_DELAY,
+                    ThreadPool.Names.GENERIC,
+                    () -> reloadApiTokensOnNodeStart(listener)
+                );
+                return;
+            }
+            listener.onFailure(e);
+        }));
     }
 
     private static RoleV7 buildRole(ApiToken tokenMetadata) {
@@ -181,15 +207,17 @@ public class ApiTokenRepository {
 
     public ApiTokenRepository(Client client, ClusterService clusterService) {
         apiTokenIndexHandler = new ApiTokenIndexHandler(client, clusterService);
+        threadPool = client.threadPool();
     }
 
-    private ApiTokenRepository(ApiTokenIndexHandler apiTokenIndexHandler) {
+    private ApiTokenRepository(ApiTokenIndexHandler apiTokenIndexHandler, ThreadPool threadPool) {
         this.apiTokenIndexHandler = apiTokenIndexHandler;
+        this.threadPool = threadPool;
     }
 
     @VisibleForTesting
-    static ApiTokenRepository forTest(ApiTokenIndexHandler apiTokenIndexHandler) {
-        return new ApiTokenRepository(apiTokenIndexHandler);
+    static ApiTokenRepository forTest(ApiTokenIndexHandler apiTokenIndexHandler, ThreadPool threadPool) {
+        return new ApiTokenRepository(apiTokenIndexHandler, threadPool);
     }
 
     public record TokenCreated(String id, String token) {

--- a/src/test/java/org/opensearch/security/action/apitokens/ApiTokenRepositoryTests.java
+++ b/src/test/java/org/opensearch/security/action/apitokens/ApiTokenRepositoryTests.java
@@ -25,11 +25,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.cluster.block.ClusterBlockException;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.discovery.ClusterManagerNotDiscoveredException;
+import org.opensearch.gateway.GatewayService;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.user.User;
 import org.opensearch.security.util.ActionListenerUtils.TestActionListener;
+import org.opensearch.threadpool.ThreadPool;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -44,6 +49,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @SuppressWarnings("unchecked")
@@ -68,6 +75,7 @@ public class ApiTokenRepositoryTests extends LuceneTestCase {
     private static final String HASH_TEST = ApiTokenRepository.hashToken(TOKEN_TEST);
     private static final String HASH_EXISTS = ApiTokenRepository.hashToken(TOKEN_EXISTS);
     private ApiTokenIndexHandler apiTokenIndexHandler;
+    private ThreadPool threadPool;
     private ApiTokenRepository repository;
 
     @Override
@@ -75,7 +83,8 @@ public class ApiTokenRepositoryTests extends LuceneTestCase {
     public void setUp() throws Exception {
         super.setUp();
         apiTokenIndexHandler = mock(ApiTokenIndexHandler.class);
-        repository = ApiTokenRepository.forTest(apiTokenIndexHandler);
+        threadPool = mock(ThreadPool.class);
+        repository = ApiTokenRepository.forTest(apiTokenIndexHandler, threadPool);
     }
 
     @Test
@@ -372,6 +381,73 @@ public class ApiTokenRepositoryTests extends LuceneTestCase {
         repository.reloadApiTokensFromIndex(ActionListener.wrap(unused -> callCount[0]++, e -> {}));
 
         assertEquals("Listener should be called exactly once regardless of token count", 1, callCount[0]);
+    }
+
+    @Test
+    public void testReloadApiTokensOnNodeStartRetriesStateNotRecoveredBlock() {
+        doAnswer(invocation -> {
+            ActionListener<Map<String, ApiToken>> listener = invocation.getArgument(0);
+            listener.onFailure(new ClusterBlockException(Collections.singleton(GatewayService.STATE_NOT_RECOVERED_BLOCK)));
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<Map<String, ApiToken>> listener = invocation.getArgument(0);
+            listener.onResponse(Collections.emptyMap());
+            return null;
+        }).when(apiTokenIndexHandler).getTokenMetadatas(any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            Runnable retry = invocation.getArgument(2);
+            retry.run();
+            return null;
+        }).when(threadPool).scheduleUnlessShuttingDown(any(TimeValue.class), eq(ThreadPool.Names.GENERIC), any(Runnable.class));
+
+        TestActionListener<Void> listener = new TestActionListener<>();
+        repository.reloadApiTokensOnNodeStart(listener);
+
+        listener.assertSuccess();
+        verify(apiTokenIndexHandler, times(2)).getTokenMetadatas(any(ActionListener.class));
+        verify(threadPool).scheduleUnlessShuttingDown(any(TimeValue.class), eq(ThreadPool.Names.GENERIC), any(Runnable.class));
+    }
+
+    @Test
+    public void testReloadApiTokensOnNodeStartRetriesMissingClusterManager() {
+        doAnswer(invocation -> {
+            ActionListener<Map<String, ApiToken>> listener = invocation.getArgument(0);
+            listener.onFailure(new ClusterManagerNotDiscoveredException());
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<Map<String, ApiToken>> listener = invocation.getArgument(0);
+            listener.onResponse(Collections.emptyMap());
+            return null;
+        }).when(apiTokenIndexHandler).getTokenMetadatas(any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            Runnable retry = invocation.getArgument(2);
+            retry.run();
+            return null;
+        }).when(threadPool).scheduleUnlessShuttingDown(any(TimeValue.class), eq(ThreadPool.Names.GENERIC), any(Runnable.class));
+
+        TestActionListener<Void> listener = new TestActionListener<>();
+        repository.reloadApiTokensOnNodeStart(listener);
+
+        listener.assertSuccess();
+        verify(apiTokenIndexHandler, times(2)).getTokenMetadatas(any(ActionListener.class));
+        verify(threadPool).scheduleUnlessShuttingDown(any(TimeValue.class), eq(ThreadPool.Names.GENERIC), any(Runnable.class));
+    }
+
+    @Test
+    public void testReloadApiTokensOnNodeStartDoesNotRetryUnexpectedFailure() {
+        doAnswer(invocation -> {
+            ActionListener<Map<String, ApiToken>> listener = invocation.getArgument(0);
+            listener.onFailure(new IllegalStateException("unexpected"));
+            return null;
+        }).when(apiTokenIndexHandler).getTokenMetadatas(any(ActionListener.class));
+
+        TestActionListener<Void> listener = new TestActionListener<>();
+        repository.reloadApiTokensOnNodeStart(listener);
+
+        listener.assertException(OpenSearchSecurityException.class);
+        verify(threadPool, never()).scheduleUnlessShuttingDown(any(TimeValue.class), any(String.class), any(Runnable.class));
     }
 
     @Test


### PR DESCRIPTION
### Description
* Category: Bug fix
* API token metadata loading now retries during node startup when the cluster is temporarily blocked by a retryable cluster block or when a cluster manager has not yet been discovered.
* Previously, the one-shot reload could run before gateway recovery completed, leaving the startup token cache empty and logging a warning.
* Retries use the OpenSearch thread pool with a one-second delay and stop being scheduled when the node is shutting down. Unexpected failures still reach the original warning path.

### Issues Resolved
Closes #6288

This is not a backport.

This change does not introduce new permissions.

### Testing
* `./gradlew test --tests org.opensearch.security.action.apitokens.ApiTokenRepositoryTests`
* `./gradlew spotlessCheck checkstyleMain checkstyleTest spotbugsMain`
* `./gradlew precommit` reaches the unrelated sample resource plugin and fails on its existing forbidden `URL.openStream()` usages in `CreateResourceTransportAction` and `CreateResourceGroupTransportAction`.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
