### PR TITLE
Preserve authentication for self-referential CCS

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1737,7 +1737,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             SSLConfig,
             OpenSearchSecurityPlugin::isActionTraceEnabled,
             userFactory,
-            remoteClusterIdentityPolicy
+            remoteClusterIdentityPolicy,
+            GuiceHolder::getLocalNodeConnection
         );
         components.add(principalExtractor);
 
@@ -2977,6 +2978,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     public static class GuiceHolder implements LifecycleComponent {
 
         private static RepositoriesService repositoriesService;
+        private static TransportService transportService;
         private static RemoteClusterService remoteClusterService;
         private static IndicesService indicesService;
         private static PitService pitService;
@@ -2989,7 +2991,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         @Inject
         public GuiceHolder(
             final RepositoriesService repositoriesService,
-            final TransportService remoteClusterService,
+            final TransportService transportService,
             IndicesService indicesService,
             PitService pitService,
             ExtensionsManager extensionsManager,
@@ -2997,7 +2999,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             AuditLogImpl auditLog
         ) {
             GuiceHolder.repositoriesService = repositoriesService;
-            GuiceHolder.remoteClusterService = remoteClusterService.getRemoteClusterService();
+            GuiceHolder.transportService = transportService;
+            GuiceHolder.remoteClusterService = transportService.getRemoteClusterService();
             GuiceHolder.indicesService = indicesService;
             GuiceHolder.pitService = pitService;
             GuiceHolder.extensionsManager = extensionsManager;
@@ -3011,6 +3014,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         public static RemoteClusterService getRemoteClusterService() {
             return remoteClusterService;
+        }
+
+        public static Connection getLocalNodeConnection(DiscoveryNode localNode) {
+            return transportService == null || localNode == null ? null : transportService.getConnection(localNode);
         }
 
         public static IndicesService getIndicesService() {

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -32,8 +32,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -95,6 +97,7 @@ public class SecurityInterceptor {
     private final Supplier<Boolean> actionTraceEnabled;
     private final UserFactory userFactory;
     private final RemoteClusterIdentityPolicy remoteClusterIdentityPolicy;
+    private final Function<DiscoveryNode, Connection> localNodeConnectionProvider;
 
     public SecurityInterceptor(
         final Settings settings,
@@ -109,7 +112,8 @@ public class SecurityInterceptor {
         final SSLConfig SSLConfig,
         final Supplier<Boolean> actionTraceSupplier,
         final UserFactory userFactory,
-        final RemoteClusterIdentityPolicy remoteClusterIdentityPolicy
+        final RemoteClusterIdentityPolicy remoteClusterIdentityPolicy,
+        final Function<DiscoveryNode, Connection> localNodeConnectionProvider
     ) {
         this.backendRegistry = backendRegistry;
         this.auditLog = auditLog;
@@ -124,6 +128,7 @@ public class SecurityInterceptor {
         this.actionTraceEnabled = actionTraceSupplier;
         this.userFactory = userFactory;
         this.remoteClusterIdentityPolicy = remoteClusterIdentityPolicy;
+        this.localNodeConnectionProvider = localNodeConnectionProvider;
     }
 
     public <T extends TransportRequest> SecurityRequestHandler<T> getHandler(String action, TransportRequestHandler<T> actualHandler) {
@@ -170,7 +175,8 @@ public class SecurityInterceptor {
         final boolean isDebugEnabled = log.isDebugEnabled();
         final boolean isStreamChannel = options != null && TransportRequestOptions.Type.STREAM.equals(options.type());
         // skip the same node optimization for stream transport which doesn't use DirectChannel and thus ser/de is needed
-        final boolean isSameNodeRequest = localNode != null && localNode.equals(connection.getNode()) && !isStreamChannel;
+        final boolean isSameNodeRequest = Objects.requireNonNull(connection) == localNodeConnectionProvider.apply(localNode)
+            && !isStreamChannel;
         final Set<String> requestHeadersToCopy = new HashSet<>();
         if (getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS) != null) {
             Collections.addAll(

--- a/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
@@ -72,6 +72,7 @@ public class RestoringTransportResponseHandlerTests {
             null,
             () -> false,
             null,
+            null,
             null
         );
         return interceptor.new RestoringTransportResponseHandler<>(innerHandler, restorableContext);

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -162,7 +162,18 @@ public class SecurityInterceptorTests {
             sslConfig,
             () -> true,
             new UserFactory.Simple(),
-            new RemoteClusterIdentityPolicy(false)
+            new RemoteClusterIdentityPolicy(false),
+            node -> {
+                if (node == null) {
+                    return null;
+                } else if (node.equals(localNode)) {
+                    return connection1;
+                } else if (node.equals(otherNode)) {
+                    return connection2;
+                } else {
+                    return null;
+                }
+            }
         ) {
             @Override
             boolean isCrossClusterSearchEnabled() {
@@ -336,7 +347,8 @@ public class SecurityInterceptorTests {
             sslConfig,
             () -> true,
             new UserFactory.Simple(),
-            new RemoteClusterIdentityPolicy(false)
+            new RemoteClusterIdentityPolicy(false),
+            node -> null
         );
 
         assertFalse(interceptor.isCrossClusterSearchEnabled());
@@ -358,6 +370,14 @@ public class SecurityInterceptorTests {
         completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, localNode);
         // this is a remote request where the transport address is different
         completableRequestDecorate(jdkSerializedSender, connection4, action, request, options, handler, localNode);
+    }
+
+    @Test
+    public void testRemoteConnectionTargetingLocalNodeUsesSerialization() {
+        Connection remoteConnectionToLocalNode = mock(Connection.class);
+        when(remoteConnectionToLocalNode.getNode()).thenReturn(localNode);
+
+        completableRequestDecorate(jdkSerializedSender, remoteConnectionToLocalNode, action, request, options, handler, localNode);
     }
 
     @Test


### PR DESCRIPTION
Fixes #5846

## Summary
- identify direct local transport requests by the exact local `DiscoveryNode` instance rather than `DiscoveryNode.equals`
- serialize user context for equal-but-distinct remote node representations, including self-referential CCS
- add regression coverage for a remote connection whose `DiscoveryNode` equals, but is not identical to, the local node

## Validation
- `./gradlew spotlessJavaCheck test --tests org.opensearch.security.transport.SecurityInterceptorTests --tests org.opensearch.security.transport.RestoringTransportResponseHandlerTests`
- reproduced with two OpenSearch 3.7.0 clusters and both self-referential and external remote aliases
- before fix: self CCS returned HTTP 500 in 5/5 requests; external CCS returned HTTP 200
- after identity-based fix: self CCS returned HTTP 200 in 5/5 requests; external CCS returned HTTP 200 in 3/3 requests

## Note
- `./gradlew precommit` reaches an unrelated existing forbidden-API failure in the sample resource plugin for `URL.openStream()`
