### PR TITLE
Preserve authentication for self-referential CCS

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2989,7 +2989,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         @Inject
         public GuiceHolder(
             final RepositoriesService repositoriesService,
-            final TransportService remoteClusterService,
+            final TransportService transportService,
             IndicesService indicesService,
             PitService pitService,
             ExtensionsManager extensionsManager,
@@ -2997,7 +2997,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             AuditLogImpl auditLog
         ) {
             GuiceHolder.repositoriesService = repositoriesService;
-            GuiceHolder.remoteClusterService = remoteClusterService.getRemoteClusterService();
+            GuiceHolder.remoteClusterService = transportService.getRemoteClusterService();
             GuiceHolder.indicesService = indicesService;
             GuiceHolder.pitService = pitService;
             GuiceHolder.extensionsManager = extensionsManager;

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -170,7 +170,8 @@ public class SecurityInterceptor {
         final boolean isDebugEnabled = log.isDebugEnabled();
         final boolean isStreamChannel = options != null && TransportRequestOptions.Type.STREAM.equals(options.type());
         // skip the same node optimization for stream transport which doesn't use DirectChannel and thus ser/de is needed
-        final boolean isSameNodeRequest = localNode != null && localNode.equals(connection.getNode()) && !isStreamChannel;
+        // An equal but distinct node may represent a remote connection back to this node, so use identity for direct local requests.
+        final boolean isSameNodeRequest = localNode != null && connection.getNode() == localNode && !isStreamChannel;
         final Set<String> requestHeadersToCopy = new HashSet<>();
         if (getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS) != null) {
             Collections.addAll(

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -66,6 +66,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -358,6 +359,18 @@ public class SecurityInterceptorTests {
         completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, localNode);
         // this is a remote request where the transport address is different
         completableRequestDecorate(jdkSerializedSender, connection4, action, request, options, handler, localNode);
+    }
+
+    @Test
+    public void testRemoteConnectionTargetingLocalNodeUsesSerialization() {
+        DiscoveryNode remoteViewOfLocalNode = new DiscoveryNode(localNode, localNode.getAddress());
+        assertThat(remoteViewOfLocalNode, is(localNode));
+        assertNotSame(remoteViewOfLocalNode, localNode);
+
+        Connection remoteConnectionToLocalNode = mock(Connection.class);
+        when(remoteConnectionToLocalNode.getNode()).thenReturn(remoteViewOfLocalNode);
+
+        completableRequestDecorate(jdkSerializedSender, remoteConnectionToLocalNode, action, request, options, handler, localNode);
     }
 
     @Test


### PR DESCRIPTION
Fixes #5846

## Summary
- identify direct local transport requests by the exact local `DiscoveryNode` instance rather than `DiscoveryNode.equals`
- serialize user context for equal-but-distinct remote node representations, including self-referential CCS
- add regression coverage for a remote connection whose `DiscoveryNode` equals, but is not identical to, the local node

## Validation
- `./gradlew spotlessJavaCheck test --tests org.opensearch.security.transport.SecurityInterceptorTests --tests org.opensearch.security.transport.RestoringTransportResponseHandlerTests`
- reproduced with two OpenSearch 3.7.0 clusters and both self-referential and external remote aliases
- before fix: self CCS returned HTTP 500 in 5/5 requests; external CCS returned HTTP 200
- after identity-based fix: self CCS returned HTTP 200 in 5/5 requests; external CCS returned HTTP 200 in 3/3 requests

## Note
- `./gradlew precommit` reaches an unrelated existing forbidden-API failure in the sample resource plugin for `URL.openStream()`
