### PR TITLE
Support keystore references in dynamic security config

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -176,6 +176,8 @@ config:
             verify_hostnames: true
             hosts:
             - localhost:8389
+            # Values can reference plugins.security.dynamic_config.secrets.* entries in opensearch-keystore,
+            # for example ${keystore:ldap.bind_dn} and ${keystore:ldap.password}.
             bind_dn: null
             password: null
             userbase: 'ou=people,dc=example,dc=com'
@@ -203,6 +205,8 @@ config:
             verify_hostnames: true
             hosts:
             - localhost:8389
+            # Values can reference plugins.security.dynamic_config.secrets.* entries in opensearch-keystore,
+            # for example ${keystore:ldap.bind_dn} and ${keystore:ldap.password}.
             bind_dn: null
             password: null
             rolebase: 'ou=groups,dc=example,dc=com'

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -126,6 +126,7 @@ import org.opensearch.plugins.ExtensionAwarePlugin;
 import org.opensearch.plugins.IdentityPlugin;
 import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.ReloadablePlugin;
 import org.opensearch.plugins.SecureHttpTransportSettingsProvider;
 import org.opensearch.plugins.SecureSettingsFactory;
 import org.opensearch.plugins.SecureTransportSettingsProvider;
@@ -217,6 +218,7 @@ import org.opensearch.security.rest.SecurityInfoAction;
 import org.opensearch.security.rest.SecurityWhoAmIAction;
 import org.opensearch.security.rest.TenantInfoAction;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
+import org.opensearch.security.securityconf.DynamicConfigSecrets;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.setting.OpensearchDynamicSetting;
@@ -285,7 +287,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         MapperPlugin,
         IdentityPlugin,
         ExtensionAwarePlugin,
-        ExtensiblePlugin
+        ExtensiblePlugin,
+        ReloadablePlugin
 
 {
 
@@ -316,6 +319,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     private volatile Client localClient;
     private final boolean disabled;
     private final Settings pluginSettings;
+    private final DynamicConfigSecrets dynamicConfigSecrets;
     private volatile SecurityTokenManager tokenManager;
     private volatile DynamicConfigFactory dcf;
     private final List<String> demoCertHashes = new ArrayList<String>(3);
@@ -348,6 +352,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     @Override
     public void close() throws IOException {
         super.close();
+        dynamicConfigSecrets.close();
         if (auditLog != null) {
             auditLog.close();
         }
@@ -605,6 +610,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         super(settings, configPath, isDisabled(settings));
 
         this.pluginSettings = settings;
+        this.dynamicConfigSecrets = new DynamicConfigSecrets(settings);
         disabled = isDisabled(settings);
         sslCertReloadEnabled = isSslCertReloadEnabled(settings);
 
@@ -1702,7 +1708,17 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             configPath,
             compatConfig
         );
-        dcf = new DynamicConfigFactory(cr, settings, configPath, localClient, threadPool, cih, passwordHasher, apiTokenRepository);
+        dcf = new DynamicConfigFactory(
+            cr,
+            settings,
+            configPath,
+            localClient,
+            threadPool,
+            cih,
+            passwordHasher,
+            apiTokenRepository,
+            dynamicConfigSecrets
+        );
         dcf.registerDCFListener(backendRegistry);
         dcf.registerDCFListener(compatConfig);
         dcf.registerDCFListener(xffResolver);
@@ -1818,6 +1834,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = new ArrayList<Setting<?>>();
         settings.addAll(super.getSettings());
+        settings.add(DynamicConfigSecrets.SETTING);
 
         settings.add(Setting.boolSetting(ConfigConstants.SECURITY_SSL_ONLY, false, Property.NodeScope, Property.Filtered));
 
@@ -2747,6 +2764,16 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         }
 
         return settings;
+    }
+
+    @Override
+    public void reload(Settings settings) {
+        dynamicConfigSecrets.reload(settings, () -> {
+            DynamicConfigFactory currentDynamicConfigFactory = dcf;
+            if (currentDynamicConfigFactory != null && currentDynamicConfigFactory.isInitialized()) {
+                currentDynamicConfigFactory.reloadFromCurrentConfiguration();
+            }
+        });
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -145,6 +145,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     private final ThreadPool threadPool;
     private final Client client;
     private final ApiTokenRepository apiTokenRepository;
+    private final DynamicConfigSecrets dynamicConfigSecrets;
 
     SecurityDynamicConfiguration<?> config;
 
@@ -156,7 +157,8 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         ThreadPool threadPool,
         ClusterInfoHolder cih,
         PasswordHasher passwordHasher,
-        ApiTokenRepository apiTokenRepository
+        ApiTokenRepository apiTokenRepository,
+        DynamicConfigSecrets dynamicConfigSecrets
     ) {
         super();
         this.cr = cr;
@@ -167,6 +169,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         this.threadPool = threadPool;
         this.client = client;
         this.apiTokenRepository = apiTokenRepository;
+        this.dynamicConfigSecrets = dynamicConfigSecrets;
 
         if (opensearchSettings.getAsBoolean(ConfigConstants.SECURITY_UNSUPPORTED_LOAD_STATIC_RESOURCES, true)) {
             try {
@@ -274,7 +277,15 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         );
 
         // rebuild v7 Models
-        dcm = new DynamicConfigModelV7(getConfigV7(config), opensearchSettings, configPath, iab, this.cih, apiTokenRepository);
+        dcm = new DynamicConfigModelV7(
+            getConfigV7(config),
+            opensearchSettings,
+            configPath,
+            iab,
+            this.cih,
+            apiTokenRepository,
+            dynamicConfigSecrets
+        );
         ium = new InternalUsersModelV7(internalusers, roles, rolesmapping);
 
         // notify subscribers
@@ -338,6 +349,10 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     @Override
     public boolean isInitialized() {
         return initialized.get();
+    }
+
+    public void reloadFromCurrentConfiguration() {
+        onChange(ConfigurationMap.EMPTY);
     }
 
     public void registerDCFListener(Object listener) {

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
@@ -84,6 +84,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
     private Multimap<String, ClientBlockRegistry<String>> authBackendClientBlockRegistries;
     private final ClusterInfoHolder cih;
     private final ApiTokenRepository apiTokenRepository;
+    private final DynamicConfigSecrets dynamicConfigSecrets;
 
     public DynamicConfigModelV7(
         ConfigV7 config,
@@ -91,7 +92,8 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         Path configPath,
         InternalAuthenticationBackend iab,
         ClusterInfoHolder cih,
-        ApiTokenRepository apiTokenRepository
+        ApiTokenRepository apiTokenRepository,
+        DynamicConfigSecrets dynamicConfigSecrets
     ) {
         super();
         this.config = config;
@@ -100,6 +102,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         this.iab = iab;
         this.cih = cih;
         this.apiTokenRepository = apiTokenRepository;
+        this.dynamicConfigSecrets = dynamicConfigSecrets;
         buildAAA();
     }
 
@@ -232,6 +235,8 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
     private void buildAAA() {
 
+        validateSecretReferences();
+
         final SortedSet<AuthDomain> restAuthDomains0 = new TreeSet<>();
         final Set<AuthorizationBackend> restAuthorizers0 = new HashSet<>();
         final List<Destroyable> destroyableComponents0 = new LinkedList<>();
@@ -260,16 +265,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
                         authorizationBackend = newInstance(
                             authzBackendClazz,
                             "z",
-                            Settings.builder()
-                                .put(opensearchSettings)
-                                // .putProperties(ads.getAsStringMap(DotPath.of("authorization_backend.config")),
-                                // DynamicConfiguration.checkKeyFunction()).build(), configPath);
-                                .put(
-                                    Settings.builder()
-                                        .loadFromSource(ad.getValue().authorization_backend.configAsJson(), XContentType.JSON)
-                                        .build()
-                                )
-                                .build(),
+                            dynamicSettings(ad.getValue().authorization_backend.configAsJson()),
                             configPath
                         );
                     }
@@ -305,16 +301,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
                         authenticationBackend = newInstance(
                             authBackendClazz,
                             "c",
-                            Settings.builder()
-                                .put(opensearchSettings)
-                                // .putProperties(ads.getAsStringMap(DotPath.of("authentication_backend.config")),
-                                // DynamicConfiguration.checkKeyFunction()).build()
-                                .put(
-                                    Settings.builder()
-                                        .loadFromSource(ad.getValue().authentication_backend.configAsJson(), XContentType.JSON)
-                                        .build()
-                                )
-                                .build(),
+                            dynamicSettings(ad.getValue().authentication_backend.configAsJson()),
                             configPath
                         );
                     }
@@ -325,18 +312,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
                         : (HTTPAuthenticator) newInstance(
                             httpAuthenticatorType,
                             "h",
-                            Settings.builder()
-                                .put(opensearchSettings)
-                                // .putProperties(ads.getAsStringMap(DotPath.of("http_authenticator.config")),
-                                // DynamicConfiguration.checkKeyFunction()).build(),
-                                .put(
-                                    Settings.builder()
-                                        .loadFromSource(ad.getValue().http_authenticator.configAsJson(), XContentType.JSON)
-                                        .build()
-                                )
-                                .build()
-
-                            ,
+                            dynamicSettings(ad.getValue().http_authenticator.configAsJson()),
                             configPath
                         );
 
@@ -429,6 +405,29 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         authBackendClientBlockRegistries = Multimaps.unmodifiableMultimap(authBackendClientBlockRegistries0);
         authBackendFailureListeners = Multimaps.unmodifiableMultimap(authBackendFailureListeners0);
 
+    }
+
+    private Settings dynamicSettings(String configJson) {
+        Settings dynamicSettings = Settings.builder().loadFromSource(configJson, XContentType.JSON).build();
+        return Settings.builder().put(opensearchSettings).put(dynamicConfigSecrets.resolve(dynamicSettings)).build();
+    }
+
+    private void validateSecretReferences() {
+        config.dynamic.authz.getDomains()
+            .values()
+            .stream()
+            .filter(domain -> domain.http_enabled)
+            .forEach(domain -> dynamicConfigSecrets.validate(loadSettings(domain.authorization_backend.configAsJson())));
+        config.dynamic.authc.getDomains().values().stream().filter(domain -> domain.http_enabled).forEach(domain -> {
+            dynamicConfigSecrets.validate(loadSettings(domain.authentication_backend.configAsJson()));
+            if (domain.http_authenticator.type != null) {
+                dynamicConfigSecrets.validate(loadSettings(domain.http_authenticator.configAsJson()));
+            }
+        });
+    }
+
+    private Settings loadSettings(String configJson) {
+        return Settings.builder().loadFromSource(configJson, XContentType.JSON).build();
     }
 
     private void destroyDestroyables(List<Destroyable> destroyableComponents) {

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigSecrets.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigSecrets.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.securityconf;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.opensearch.common.settings.SecureSetting;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.core.common.settings.SecureString;
+
+public final class DynamicConfigSecrets implements AutoCloseable {
+
+    public static final String SETTING_PREFIX = "plugins.security.dynamic_config.secrets.";
+
+    public static final Setting.AffixSetting<SecureString> SETTING = Setting.prefixKeySetting(
+        SETTING_PREFIX,
+        key -> SecureSetting.secureString(key, null)
+    );
+
+    private static final Pattern REFERENCE_PATTERN = Pattern.compile("\\$\\{keystore:([A-Za-z0-9_.-]+)}");
+
+    private Map<String, char[]> secrets;
+
+    public DynamicConfigSecrets(Settings settings) {
+        this.secrets = load(settings);
+    }
+
+    public synchronized Settings resolve(Settings settings) {
+        Settings.Builder resolved = Settings.builder().put(settings);
+        settings.keySet().forEach(key -> {
+            String value = settings.get(key);
+            if (value != null) {
+                resolved.put(key, resolve(value));
+            }
+        });
+        return resolved.build();
+    }
+
+    public synchronized void validate(Settings settings) {
+        settings.keySet().forEach(key -> {
+            String value = settings.get(key);
+            if (value != null) {
+                resolve(value);
+            }
+        });
+    }
+
+    public synchronized void reload(Settings settings, Runnable rebuild) {
+        Map<String, char[]> replacement = load(settings);
+        Map<String, char[]> previous = secrets;
+        secrets = replacement;
+        try {
+            rebuild.run();
+            clear(previous);
+        } catch (RuntimeException | Error e) {
+            secrets = previous;
+            clear(replacement);
+            try {
+                rebuild.run();
+            } catch (RuntimeException | Error rollbackException) {
+                e.addSuppressed(rollbackException);
+            }
+            throw e;
+        }
+    }
+
+    private String resolve(String value) {
+        Matcher matcher = REFERENCE_PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            return value;
+        }
+
+        String alias = matcher.group(1);
+        char[] secret = secrets.get(alias);
+        if (secret == null) {
+            throw new SettingsException("Keystore setting [" + SETTING_PREFIX + alias + "] referenced by dynamic configuration is missing");
+        }
+        return new String(secret);
+    }
+
+    private static Map<String, char[]> load(Settings settings) {
+        Map<String, char[]> loaded = new HashMap<>();
+        try {
+            SETTING.getAsMap(settings).forEach((alias, secureString) -> {
+                try (secureString) {
+                    loaded.put(alias, secureString.getChars().clone());
+                }
+            });
+            return Collections.unmodifiableMap(loaded);
+        } catch (RuntimeException | Error e) {
+            clear(loaded);
+            throw e;
+        }
+    }
+
+    private static void clear(Map<String, char[]> secrets) {
+        secrets.values().forEach(secret -> Arrays.fill(secret, '\0'));
+    }
+
+    @Override
+    public synchronized void close() {
+        clear(secrets);
+        secrets = Collections.emptyMap();
+    }
+}

--- a/src/test/java/org/opensearch/security/securityconf/DynamicConfigModelV7Tests.java
+++ b/src/test/java/org/opensearch/security/securityconf/DynamicConfigModelV7Tests.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.securityconf;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.common.settings.MockSecureSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.security.action.apitokens.ApiTokenRepository;
+import org.opensearch.security.auth.AuthenticationBackend;
+import org.opensearch.security.auth.AuthenticationContext;
+import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
+import org.opensearch.security.configuration.ClusterInfoHolder;
+import org.opensearch.security.securityconf.impl.v7.ConfigV7;
+import org.opensearch.security.securityconf.impl.v7.ConfigV7.AuthcDomain;
+import org.opensearch.security.user.User;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+public class DynamicConfigModelV7Tests {
+
+    @Test
+    public void testResolvesAuthenticationBackendSettings() {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(DynamicConfigSecrets.SETTING_PREFIX + "ldap.bind_dn", "cn=admin,dc=example,dc=com");
+        secureSettings.setString(DynamicConfigSecrets.SETTING_PREFIX + "ldap.password", "secret");
+        ConfigV7 config = configWithPassword("${keystore:ldap.password}");
+
+        try (DynamicConfigSecrets secrets = new DynamicConfigSecrets(Settings.builder().setSecureSettings(secureSettings).build())) {
+            new DynamicConfigModelV7(
+                config,
+                Settings.EMPTY,
+                null,
+                mock(InternalAuthenticationBackend.class),
+                mock(ClusterInfoHolder.class),
+                mock(ApiTokenRepository.class),
+                secrets
+            );
+        }
+
+        assertThat(CapturingAuthenticationBackend.SETTINGS.get().get("bind_dn"), is("cn=admin,dc=example,dc=com"));
+        assertThat(CapturingAuthenticationBackend.SETTINGS.get().get("password"), is("secret"));
+    }
+
+    @Test
+    public void testRejectsMissingAuthenticationBackendSecret() {
+        ConfigV7 config = configWithPassword("${keystore:ldap.password}");
+
+        try (DynamicConfigSecrets secrets = new DynamicConfigSecrets(Settings.EMPTY)) {
+            assertThrows(
+                SettingsException.class,
+                () -> new DynamicConfigModelV7(
+                    config,
+                    Settings.EMPTY,
+                    null,
+                    mock(InternalAuthenticationBackend.class),
+                    mock(ClusterInfoHolder.class),
+                    mock(ApiTokenRepository.class),
+                    secrets
+                )
+            );
+        }
+    }
+
+    private static ConfigV7 configWithPassword(String password) {
+        ConfigV7 config = new ConfigV7();
+        config.dynamic = new ConfigV7.Dynamic();
+        AuthcDomain domain = new AuthcDomain();
+        domain.authentication_backend.type = CapturingAuthenticationBackend.class.getName();
+        domain.authentication_backend.config = Map.of("bind_dn", "${keystore:ldap.bind_dn}", "password", password);
+        config.dynamic.authc.getDomains().put("ldap", domain);
+        return config;
+    }
+
+    public static class CapturingAuthenticationBackend implements AuthenticationBackend {
+        private static final AtomicReference<Settings> SETTINGS = new AtomicReference<>();
+
+        public CapturingAuthenticationBackend(Settings settings, Path configPath) {
+            SETTINGS.set(settings);
+        }
+
+        @Override
+        public String getType() {
+            return "capturing";
+        }
+
+        @Override
+        public User authenticate(AuthenticationContext context) throws OpenSearchSecurityException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/org/opensearch/security/securityconf/DynamicConfigSecretsTests.java
+++ b/src/test/java/org/opensearch/security/securityconf/DynamicConfigSecretsTests.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.securityconf;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.MockSecureSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+public class DynamicConfigSecretsTests {
+
+    @Test
+    public void testResolvesExactKeystoreReference() {
+        try (DynamicConfigSecrets secrets = new DynamicConfigSecrets(secureSettings("ldap.password", "secret"))) {
+            Settings resolved = secrets.resolve(
+                Settings.builder().put("password", "${keystore:ldap.password}").put("username", "plain-value").build()
+            );
+
+            assertThat(resolved.get("password"), is("secret"));
+            assertThat(resolved.get("username"), is("plain-value"));
+        }
+    }
+
+    @Test
+    public void testDoesNotInterpolatePartialReference() {
+        try (DynamicConfigSecrets secrets = new DynamicConfigSecrets(secureSettings("ldap.password", "secret"))) {
+            Settings resolved = secrets.resolve(Settings.builder().put("password", "prefix-${keystore:ldap.password}").build());
+
+            assertThat(resolved.get("password"), is("prefix-${keystore:ldap.password}"));
+        }
+    }
+
+    @Test
+    public void testMissingReferenceFailsValidation() {
+        try (DynamicConfigSecrets secrets = new DynamicConfigSecrets(Settings.EMPTY)) {
+            SettingsException exception = assertThrows(
+                SettingsException.class,
+                () -> secrets.validate(Settings.builder().put("password", "${keystore:ldap.password}").build())
+            );
+
+            assertThat(
+                exception.getMessage(),
+                is(
+                    "Keystore setting [plugins.security.dynamic_config.secrets.ldap.password] referenced by dynamic configuration is missing"
+                )
+            );
+        }
+    }
+
+    @Test
+    public void testReloadRollsBackWhenRebuildFails() {
+        try (DynamicConfigSecrets secrets = new DynamicConfigSecrets(secureSettings("ldap.password", "old-secret"))) {
+            AtomicInteger rebuildCount = new AtomicInteger();
+
+            assertThrows(IllegalStateException.class, () -> secrets.reload(secureSettings("ldap.password", "new-secret"), () -> {
+                if (rebuildCount.incrementAndGet() == 1) {
+                    assertResolvedPassword(secrets, "new-secret");
+                    throw new IllegalStateException("rebuild failed");
+                }
+                assertResolvedPassword(secrets, "old-secret");
+            }));
+
+            assertThat(rebuildCount.get(), is(2));
+            assertResolvedPassword(secrets, "old-secret");
+        }
+    }
+
+    @Test
+    public void testReloadReplacesSecrets() {
+        try (DynamicConfigSecrets secrets = new DynamicConfigSecrets(secureSettings("ldap.password", "old-secret"))) {
+            secrets.reload(secureSettings("ldap.password", "new-secret"), () -> assertResolvedPassword(secrets, "new-secret"));
+
+            assertResolvedPassword(secrets, "new-secret");
+        }
+    }
+
+    private static void assertResolvedPassword(DynamicConfigSecrets secrets, String expected) {
+        Settings resolved = secrets.resolve(Settings.builder().put("password", "${keystore:ldap.password}").build());
+        assertThat(resolved.get("password"), is(expected));
+    }
+
+    private static Settings secureSettings(String alias, String value) {
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(DynamicConfigSecrets.SETTING_PREFIX + alias, value);
+        return Settings.builder().setSecureSettings(secureSettings).build();
+    }
+}


### PR DESCRIPTION
Fixes #4004

## Summary
- register a plugin-scoped `plugins.security.dynamic_config.secrets.*` secure-setting namespace
- allow dynamic authentication and authorization backend settings to reference aliases with `${keystore:<alias>}`
- retain copied secret values in memory because the OpenSearch keystore is readable only during initialization and reload callbacks
- implement `ReloadablePlugin` so `POST /_nodes/reload_secure_settings` refreshes secrets and rebuilds the active security configuration
- restore the previous secret snapshot and configuration if rebuilding with reloaded values fails

## Example
Add secrets to each node:

```shell
bin/opensearch-keystore add plugins.security.dynamic_config.secrets.ldap.bind_dn
bin/opensearch-keystore add plugins.security.dynamic_config.secrets.ldap.password
```

Reference them from `config.yml` or the corresponding security-index configuration:

```yaml
bind_dn: ${keystore:ldap.bind_dn}
password: ${keystore:ldap.password}
```

After changing the values on disk, reload them across the cluster:

```http
POST /_nodes/reload_secure_settings
```

## Validation
- `./gradlew spotlessJavaCheck`
- `./gradlew checkstyleMain checkstyleTest`
- focused unit coverage for resolution, missing references, rotation, rollback, and dynamic backend construction
- relevant `DynamicConfigSecretsTests`, `DynamicConfigModelV7Tests`, and `ConfigurationRepositoryTest` suites pass

## Note
- full `precommit` reaches unrelated existing forbidden-API failures in the sample resource plugin for `URL.openStream()`
