### PR TITLE
Clarify transport security request flow

### DIFF
--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -38,7 +38,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -77,14 +76,32 @@ import org.opensearch.transport.stream.StreamTransportResponse;
 
 public class SecurityInterceptor {
 
+    private static final String ACTION_TRACE_HEADER_PREFIX = "_opendistro_security_trace";
+    private static final String SOURCE_FIELD_CONTEXT_HEADER = "_opendistro_security_source_field_context";
+    private static final Set<String> SECURITY_HEADERS_TO_COPY = Set.of(
+        ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_ORIGIN_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_USER_SAME_AS_SUBJECT_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER,
+        ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS
+    );
+
     protected final Logger log = LogManager.getLogger(getClass());
-    private BackendRegistry backendRegistry;
-    private AuditLog auditLog;
+    private final AuditLog auditLog;
     private final ThreadPool threadPool;
     private final PrincipalExtractor principalExtractor;
     private final InterClusterRequestEvaluator requestEvalProvider;
     private final ClusterService cs;
-    private final Settings settings;
     private final SslExceptionHandler sslExceptionHandler;
     private final ClusterInfoHolder clusterInfoHolder;
     private final SSLConfig SSLConfig;
@@ -107,13 +124,11 @@ public class SecurityInterceptor {
         final UserFactory userFactory,
         final RemoteClusterIdentityPolicy remoteClusterIdentityPolicy
     ) {
-        this.backendRegistry = backendRegistry;
         this.auditLog = auditLog;
         this.threadPool = threadPool;
         this.principalExtractor = principalExtractor;
         this.requestEvalProvider = requestEvalProvider;
         this.cs = cs;
-        this.settings = settings;
         this.sslExceptionHandler = sslExceptionHandler;
         this.clusterInfoHolder = clusterInfoHolder;
         this.SSLConfig = SSLConfig;
@@ -123,7 +138,7 @@ public class SecurityInterceptor {
     }
 
     public <T extends TransportRequest> SecurityRequestHandler<T> getHandler(String action, TransportRequestHandler<T> actualHandler) {
-        return new SecurityRequestHandler<T>(
+        return new SecurityRequestHandler<>(
             action,
             actualHandler,
             threadPool,
@@ -161,18 +176,7 @@ public class SecurityInterceptor {
         final boolean isStreamChannel = options != null && TransportRequestOptions.Type.STREAM.equals(options.type());
         // skip the same node optimization for stream transport which doesn't use DirectChannel and thus ser/de is needed
         final boolean isSameNodeRequest = localNode != null && localNode.equals(connection.getNode()) && !isStreamChannel;
-        final Set<String> requestHeadersToCopy = new HashSet<>();
-        if (getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS) != null) {
-            Collections.addAll(
-                requestHeadersToCopy,
-                getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS).split(",")
-            );
-            requestHeadersToCopy.removeAll(Task.REQUEST_HEADERS); // Special case where this header is preserved during stashContext.
-        }
-
-        if (!Strings.isNullOrEmpty(getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS))) {
-            requestHeadersToCopy.add(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS);
-        }
+        final Set<String> requestHeadersToCopy = getRequestHeadersToCopy();
 
         final Supplier<ThreadContext.StoredContext> restorableContextSupplier = getThreadContext().newRestorableContext(true);
         try (ThreadContext.StoredContext stashedContext = getThreadContext().stashContext()) {
@@ -182,80 +186,23 @@ public class SecurityInterceptor {
             );
             getThreadContext().putHeader("_opendistro_security_remotecn", cs.getClusterName().value());
 
-            final Map<String, String> headerMap = new HashMap<>(
-                Maps.filterKeys(
-                    origHeaders0,
-                    k -> k != null
-                        && (k.equals(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_USER_SAME_AS_SUBJECT_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER)
-                            || k.equals(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS)
-                            || (k.equals("_opendistro_security_source_field_context")
-                                && !(request instanceof SearchRequest)
-                                && !(request instanceof GetRequest))
-                            || k.startsWith("_opendistro_security_trace")
-                            || k.startsWith(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER)
-                            || requestHeadersToCopy.contains(k))
-                )
-            );
+            final Map<String, String> headerMap = createHeaderMap(origHeaders0, request, requestHeadersToCopy);
 
             if (dlsFlsLegacyHeaders != null) {
                 dlsFlsLegacyHeaders.performHeaderDecoration(connection, request, headerMap);
             }
 
-            boolean isSearchAction = action.equals(ClusterSearchShardsAction.NAME) || action.equals(SearchAction.NAME);
-            boolean isDestinationOutsideLocalCluster = clusterInfoHolder.isInitialized()
+            final boolean isDestinationOutsideLocalCluster = clusterInfoHolder.isInitialized()
                 && !clusterInfoHolder.hasNode(connection.getNode());
-
-            if (isDestinationOutsideLocalCluster) {
-                // The top-level query filter is only valid within the coordinating cluster. Strip its marker from every
-                // action sent to an unrecognized destination, even if RemoteClusterService does not report CCS as enabled.
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
-            }
-
-            if (isCrossClusterSearchEnabled() && isSearchAction && isDestinationOutsideLocalCluster) {
-                if (isDebugEnabled) {
-                    log.debug("remove dls/fls/mf because we sent a ccs request to a remote cluster");
-                }
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER);
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER);
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER);
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER);
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER);
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER);
-            }
-
-            if (isCrossClusterSearchEnabled()
-                && !action.startsWith("internal:")
-                && !action.equals(ClusterSearchShardsAction.NAME)
-                && isDestinationOutsideLocalCluster) {
-
-                if (isDebugEnabled) {
-                    log.debug("add dls/fls/mf from transient");
-                }
-
-                if (origCCSTransientDls != null && !origCCSTransientDls.isEmpty()) {
-                    headerMap.put(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER, origCCSTransientDls);
-                }
-                if (origCCSTransientMf != null && !origCCSTransientMf.isEmpty()) {
-                    headerMap.put(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER, origCCSTransientMf);
-                }
-                if (origCCSTransientFls != null && !origCCSTransientFls.isEmpty()) {
-                    headerMap.put(ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER, origCCSTransientFls);
-                }
-            }
+            decorateCrossClusterHeaders(
+                headerMap,
+                action,
+                isDestinationOutsideLocalCluster,
+                origCCSTransientDls,
+                origCCSTransientFls,
+                origCCSTransientMf,
+                isDebugEnabled
+            );
 
             if (StringUtils.isNotEmpty(injectedRolesValidationString)
                 && isCrossClusterSearchEnabled()
@@ -272,20 +219,7 @@ public class SecurityInterceptor {
 
             identityContext.propagate(getThreadContext(), isSameNodeRequest);
 
-            if (actionTraceEnabled.get()) {
-                getThreadContext().putHeader(
-                    "_opendistro_security_trace" + System.currentTimeMillis() + "#" + UUID.randomUUID().toString(),
-                    Thread.currentThread().getName()
-                        + " IC -> "
-                        + action
-                        + " "
-                        + getThreadContext().getHeaders()
-                            .entrySet()
-                            .stream()
-                            .filter(p -> !p.getKey().startsWith("_opendistro_security_trace"))
-                            .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()))
-                );
-            }
+            addActionTrace(action);
 
             sender.sendRequest(connection, action, request, options, restoringHandler);
         }
@@ -293,6 +227,106 @@ public class SecurityInterceptor {
 
     boolean isCrossClusterSearchEnabled() {
         return OpenSearchSecurityPlugin.GuiceHolder.getRemoteClusterService().isCrossClusterSearchEnabled();
+    }
+
+    private Set<String> getRequestHeadersToCopy() {
+        final Set<String> requestHeadersToCopy = new HashSet<>();
+        final String requestedHeaders = getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS);
+        if (requestedHeaders != null) {
+            Collections.addAll(requestHeadersToCopy, requestedHeaders.split(","));
+            requestHeadersToCopy.removeAll(Task.REQUEST_HEADERS);
+        }
+        if (!Strings.isNullOrEmpty(getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS))) {
+            requestHeadersToCopy.add(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS);
+        }
+        return requestHeadersToCopy;
+    }
+
+    private Map<String, String> createHeaderMap(
+        Map<String, String> originalHeaders,
+        TransportRequest request,
+        Set<String> requestHeadersToCopy
+    ) {
+        final Map<String, String> headerMap = new HashMap<>();
+        originalHeaders.forEach((header, value) -> {
+            if (shouldCopyHeader(header, request, requestHeadersToCopy)) {
+                headerMap.put(header, value);
+            }
+        });
+        return headerMap;
+    }
+
+    private boolean shouldCopyHeader(String header, TransportRequest request, Set<String> requestHeadersToCopy) {
+        return header != null
+            && (SECURITY_HEADERS_TO_COPY.contains(header)
+                || (SOURCE_FIELD_CONTEXT_HEADER.equals(header) && !(request instanceof SearchRequest) && !(request instanceof GetRequest))
+                || header.startsWith(ACTION_TRACE_HEADER_PREFIX)
+                || header.startsWith(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER)
+                || requestHeadersToCopy.contains(header));
+    }
+
+    private void decorateCrossClusterHeaders(
+        Map<String, String> headerMap,
+        String action,
+        boolean isDestinationOutsideLocalCluster,
+        String transientDls,
+        String transientFls,
+        String transientMaskedFields,
+        boolean isDebugEnabled
+    ) {
+        if (isDestinationOutsideLocalCluster) {
+            // The top-level query filter is only valid within the coordinating cluster. Strip its marker from every
+            // action sent to an unrecognized destination, even if RemoteClusterService does not report CCS as enabled.
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
+        }
+        if (!isCrossClusterSearchEnabled() || !isDestinationOutsideLocalCluster) {
+            return;
+        }
+        final boolean isSearchAction = action.equals(ClusterSearchShardsAction.NAME) || action.equals(SearchAction.NAME);
+        if (isSearchAction) {
+            if (isDebugEnabled) {
+                log.debug("remove dls/fls/mf because we sent a ccs request to a remote cluster");
+            }
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER);
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER);
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER);
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER);
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER);
+            headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER);
+        }
+        if (!action.startsWith("internal:") && !action.equals(ClusterSearchShardsAction.NAME)) {
+            if (isDebugEnabled) {
+                log.debug("add dls/fls/mf from transient");
+            }
+            putIfNotEmpty(headerMap, ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER, transientDls);
+            putIfNotEmpty(headerMap, ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER, transientFls);
+            putIfNotEmpty(headerMap, ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER, transientMaskedFields);
+        }
+    }
+
+    private void putIfNotEmpty(Map<String, String> headers, String name, String value) {
+        if (StringUtils.isNotEmpty(value)) {
+            headers.put(name, value);
+        }
+    }
+
+    private void addActionTrace(String action) {
+        if (!actionTraceEnabled.get()) {
+            return;
+        }
+        getThreadContext().putHeader(
+            ACTION_TRACE_HEADER_PREFIX + System.currentTimeMillis() + "#" + UUID.randomUUID(),
+            Thread.currentThread().getName()
+                + " IC -> "
+                + action
+                + " "
+                + getThreadContext().getHeaders()
+                    .entrySet()
+                    .stream()
+                    .filter(entry -> !entry.getKey().startsWith(ACTION_TRACE_HEADER_PREFIX))
+                    .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()))
+        );
     }
 
     private ThreadContext getThreadContext() {

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -76,26 +76,6 @@ import org.opensearch.transport.stream.StreamTransportResponse;
 
 public class SecurityInterceptor {
 
-    private static final String ACTION_TRACE_HEADER_PREFIX = "_opendistro_security_trace";
-    private static final String SOURCE_FIELD_CONTEXT_HEADER = "_opendistro_security_source_field_context";
-    private static final Set<String> SECURITY_HEADERS_TO_COPY = Set.of(
-        ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_ORIGIN_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_USER_SAME_AS_SUBJECT_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-        ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED,
-        ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER,
-        ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER,
-        ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS
-    );
-
     protected final Logger log = LogManager.getLogger(getClass());
     private final AuditLog auditLog;
     private final ThreadPool threadPool;
@@ -258,9 +238,11 @@ public class SecurityInterceptor {
 
     private boolean shouldCopyHeader(String header, TransportRequest request, Set<String> requestHeadersToCopy) {
         return header != null
-            && (SECURITY_HEADERS_TO_COPY.contains(header)
-                || (SOURCE_FIELD_CONTEXT_HEADER.equals(header) && !(request instanceof SearchRequest) && !(request instanceof GetRequest))
-                || header.startsWith(ACTION_TRACE_HEADER_PREFIX)
+            && (TransportHeaderConstants.SECURITY_HEADERS_TO_COPY.contains(header)
+                || (TransportHeaderConstants.SOURCE_FIELD_CONTEXT_HEADER.equals(header)
+                    && !(request instanceof SearchRequest)
+                    && !(request instanceof GetRequest))
+                || header.startsWith(TransportHeaderConstants.ACTION_TRACE_HEADER_PREFIX)
                 || header.startsWith(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER)
                 || requestHeadersToCopy.contains(header));
     }
@@ -316,7 +298,7 @@ public class SecurityInterceptor {
             return;
         }
         getThreadContext().putHeader(
-            ACTION_TRACE_HEADER_PREFIX + System.currentTimeMillis() + "#" + UUID.randomUUID(),
+            TransportHeaderConstants.ACTION_TRACE_HEADER_PREFIX + System.currentTimeMillis() + "#" + UUID.randomUUID(),
             Thread.currentThread().getName()
                 + " IC -> "
                 + action
@@ -324,7 +306,7 @@ public class SecurityInterceptor {
                 + getThreadContext().getHeaders()
                     .entrySet()
                     .stream()
-                    .filter(entry -> !entry.getKey().startsWith(ACTION_TRACE_HEADER_PREFIX))
+                    .filter(entry -> !entry.getKey().startsWith(TransportHeaderConstants.ACTION_TRACE_HEADER_PREFIX))
                     .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()))
         );
     }

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -28,6 +28,7 @@ package org.opensearch.security.transport;
 
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -67,6 +68,10 @@ import static org.opensearch.security.OpenSearchSecurityPlugin.isActionTraceEnab
 
 public class SecurityRequestHandler<T extends TransportRequest> extends SecuritySSLRequestHandler<T> {
 
+    private static final String DIRECT_CHANNEL_TYPE = "direct";
+    private static final String STREAM_CHANNEL_TYPE = "stream-transport";
+    private static final String ACTION_TRACE_HEADER_PREFIX = "_opendistro_security_trace";
+
     private final AuditLog auditLog;
     private final InterClusterRequestEvaluator requestEvalProvider;
     private final ClusterService cs;
@@ -101,17 +106,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
         final TransportChannel transportChannel,
         Task task
     ) throws Exception {
-        String resolvedActionClass = request.getClass().getSimpleName();
-
-        if (request instanceof BulkShardRequest) {
-            if (((BulkShardRequest) request).items().length == 1) {
-                resolvedActionClass = ((BulkShardRequest) request).items()[0].request().getClass().getSimpleName();
-            }
-        }
-
-        if (request instanceof ConcreteShardRequest) {
-            resolvedActionClass = ((ConcreteShardRequest<?>) request).getRequest().getClass().getSimpleName();
-        }
+        final String resolvedActionClass = resolveActionClass(request);
 
         String initialActionClassValue = getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER);
 
@@ -141,32 +136,13 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
             getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_CHANNEL_TYPE, channelType);
             getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_ACTION_NAME, task.getAction());
 
-            if (request instanceof ShardSearchRequest) {
-                ShardSearchRequest sr = ((ShardSearchRequest) request);
-                if (sr.source() != null && sr.source().suggest() != null) {
-                    getThreadContext().putTransient("_opendistro_security_issuggest", Boolean.TRUE);
-                }
-                if (sr.source() != null && sr.source().query() != null) {
-                    if (ParentChildrenQueryDetector.hasParentOrChildQuery(sr.source().query())) {
-                        getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY, Boolean.TRUE);
-                    }
-                }
-            }
+            populateShardSearchContext(request);
 
             // bypass non-netty requests
             if (TransportIdentityContext.hasTransientIdentity(getThreadContext())) {
                 TransportIdentityContext.restoreRolesValidation(getThreadContext());
 
-                if (isActionTraceEnabled()) {
-                    getThreadContext().putHeader(
-                        "_opendistro_security_trace" + System.currentTimeMillis() + "#" + UUID.randomUUID().toString(),
-                        Thread.currentThread().getName()
-                            + " DIR -> "
-                            + transportChannel.getChannelType()
-                            + " "
-                            + getThreadContext().getHeaders()
-                    );
-                }
+                addActionTrace("DIR", channelType, false);
 
                 putInitialActionClassHeader(initialActionClassValue, resolvedActionClass);
             } else {
@@ -178,12 +154,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                 );
             }
 
-            if (channelType.equals("direct")) {
-                super.messageReceivedDecorate(request, handler, transportChannel, task);
-                return;
-            }
-
-            if (channelType.equals("stream-transport")) {
+            if (isDirectOrStreamChannel(channelType)) {
                 super.messageReceivedDecorate(request, handler, transportChannel, task);
                 return;
             }
@@ -193,20 +164,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
             ) == Boolean.TRUE;
 
             if (skipSecurityIfDualMode) {
-                if (getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS) == null) {
-                    getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS, request.remoteAddress());
-                }
-
-                if (getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN) == null) {
-                    getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN, Origin.TRANSPORT.toString());
-                }
-
-                if (getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_TRUSTED_CLUSTER_REQUEST) == null) {
-                    getThreadContext().putTransient(
-                        ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_TRUSTED_CLUSTER_REQUEST,
-                        Boolean.TRUE
-                    );
-                }
+                populateDualModeContext(request);
 
                 super.messageReceivedDecorate(request, handler, transportChannel, task);
                 return;
@@ -269,36 +227,14 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                     return;
                 }
 
-                if (isActionTraceEnabled()) {
-                    getThreadContext().putHeader(
-                        "_opendistro_security_trace" + System.currentTimeMillis() + "#" + UUID.randomUUID().toString(),
-                        Thread.currentThread().getName()
-                            + " NETTI -> "
-                            + transportChannel.getChannelType()
-                            + " "
-                            + getThreadContext().getHeaders()
-                                .entrySet()
-                                .stream()
-                                .filter(p -> !p.getKey().startsWith("_opendistro_security_trace"))
-                                .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()))
-                    );
-                }
+                addActionTrace("NETTI", channelType, true);
 
                 putInitialActionClassHeader(initialActionClassValue, resolvedActionClass);
             }
             super.messageReceivedDecorate(request, handler, transportChannel, task);
         } finally {
 
-            if (isActionTraceEnabled()) {
-                getThreadContext().putHeader(
-                    "_opendistro_security_trace" + System.currentTimeMillis() + "#" + UUID.randomUUID().toString(),
-                    Thread.currentThread().getName()
-                        + " FIN -> "
-                        + transportChannel.getChannelType()
-                        + " "
-                        + getThreadContext().getHeaders()
-                );
-            }
+            addActionTrace("FIN", transportChannel.getChannelType(), false);
 
             if (sgContext != null) {
                 sgContext.close();
@@ -307,15 +243,67 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
     }
 
     private void putInitialActionClassHeader(String initialActionClassValue, String resolvedActionClass) {
-        if (initialActionClassValue == null) {
-            if (getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER) == null) {
-                getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER, resolvedActionClass);
+        if (getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER) == null) {
+            getThreadContext().putHeader(
+                ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER,
+                initialActionClassValue == null ? resolvedActionClass : initialActionClassValue
+            );
+        }
+    }
+
+    private String resolveActionClass(TransportRequest request) {
+        if (request instanceof BulkShardRequest bulkShardRequest && bulkShardRequest.items().length == 1) {
+            return bulkShardRequest.items()[0].request().getClass().getSimpleName();
+        }
+        if (request instanceof ConcreteShardRequest<?> concreteShardRequest) {
+            return concreteShardRequest.getRequest().getClass().getSimpleName();
+        }
+        return request.getClass().getSimpleName();
+    }
+
+    private void populateShardSearchContext(TransportRequest request) {
+        if (request instanceof ShardSearchRequest shardSearchRequest && shardSearchRequest.source() != null) {
+            if (shardSearchRequest.source().suggest() != null) {
+                getThreadContext().putTransient("_opendistro_security_issuggest", Boolean.TRUE);
             }
-        } else {
-            if (getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER) == null) {
-                getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER, initialActionClassValue);
+            if (shardSearchRequest.source().query() != null
+                && ParentChildrenQueryDetector.hasParentOrChildQuery(shardSearchRequest.source().query())) {
+                getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY, Boolean.TRUE);
             }
         }
+    }
+
+    private boolean isDirectOrStreamChannel(String channelType) {
+        return DIRECT_CHANNEL_TYPE.equals(channelType) || STREAM_CHANNEL_TYPE.equals(channelType);
+    }
+
+    private void populateDualModeContext(TransportRequest request) {
+        if (getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS) == null) {
+            getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS, request.remoteAddress());
+        }
+        if (getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN) == null) {
+            getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN, Origin.TRANSPORT.toString());
+        }
+        if (getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_TRUSTED_CLUSTER_REQUEST) == null) {
+            getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_TRUSTED_CLUSTER_REQUEST, Boolean.TRUE);
+        }
+    }
+
+    private void addActionTrace(String stage, String channelType, boolean excludeTraceHeaders) {
+        if (!isActionTraceEnabled()) {
+            return;
+        }
+        final Map<String, String> headers = excludeTraceHeaders
+            ? getThreadContext().getHeaders()
+                .entrySet()
+                .stream()
+                .filter(entry -> !entry.getKey().startsWith(ACTION_TRACE_HEADER_PREFIX))
+                .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()))
+            : getThreadContext().getHeaders();
+        getThreadContext().putHeader(
+            ACTION_TRACE_HEADER_PREFIX + System.currentTimeMillis() + "#" + UUID.randomUUID(),
+            Thread.currentThread().getName() + " " + stage + " -> " + channelType + " " + headers
+        );
 
     }
 

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -70,8 +70,6 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
 
     private static final String DIRECT_CHANNEL_TYPE = "direct";
     private static final String STREAM_CHANNEL_TYPE = "stream-transport";
-    private static final String ACTION_TRACE_HEADER_PREFIX = "_opendistro_security_trace";
-
     private final AuditLog auditLog;
     private final InterClusterRequestEvaluator requestEvalProvider;
     private final ClusterService cs;
@@ -297,11 +295,11 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
             ? getThreadContext().getHeaders()
                 .entrySet()
                 .stream()
-                .filter(entry -> !entry.getKey().startsWith(ACTION_TRACE_HEADER_PREFIX))
+                .filter(entry -> !entry.getKey().startsWith(TransportHeaderConstants.ACTION_TRACE_HEADER_PREFIX))
                 .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()))
             : getThreadContext().getHeaders();
         getThreadContext().putHeader(
-            ACTION_TRACE_HEADER_PREFIX + System.currentTimeMillis() + "#" + UUID.randomUUID(),
+            TransportHeaderConstants.ACTION_TRACE_HEADER_PREFIX + System.currentTimeMillis() + "#" + UUID.randomUUID(),
             Thread.currentThread().getName() + " " + stage + " -> " + channelType + " " + headers
         );
 

--- a/src/main/java/org/opensearch/security/transport/TransportHeaderConstants.java
+++ b/src/main/java/org/opensearch/security/transport/TransportHeaderConstants.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.transport;
+
+import java.util.Set;
+
+import org.opensearch.security.support.ConfigConstants;
+
+final class TransportHeaderConstants {
+
+    static final String ACTION_TRACE_HEADER_PREFIX = "_opendistro_security_trace";
+    static final String SOURCE_FIELD_CONTEXT_HEADER = ConfigConstants.OPENDISTRO_SECURITY_SOURCE_FIELD_CONTEXT;
+    static final Set<String> SECURITY_HEADERS_TO_COPY = Set.of(
+        ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_ORIGIN_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_USER_SAME_AS_SUBJECT_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER,
+        ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER,
+        ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS
+    );
+
+    private TransportHeaderConstants() {}
+}


### PR DESCRIPTION
## Summary
- extract header filtering and cross-cluster decoration from the outgoing interceptor flow
- extract channel, trace, shard-search, and dual-mode helpers from the incoming request flow
- remove unused interceptor fields and simplify initial action propagation

## Testing
- `./gradlew test --tests org.opensearch.security.transport.SecurityInterceptorTests`
- `./gradlew spotlessApply precommit` *(fails in the unchanged sample resource plugin because its existing `URL#openStream()` calls violate forbidden APIs)*

This PR is intended to preserve behavior while making the transport security flow easier to follow.
