### PR TITLE
Advertise the /_plugins SAML ACS route

### DIFF
--- a/src/main/java/org/opensearch/security/auth/http/saml/Saml2SettingsProvider.java
+++ b/src/main/java/org/opensearch/security/auth/http/saml/Saml2SettingsProvider.java
@@ -46,6 +46,8 @@ import org.opensaml.xmlsec.signature.X509Certificate;
 import org.opensaml.xmlsec.signature.X509Data;
 
 public class Saml2SettingsProvider {
+
+    static final String ASSERTION_CONSUMER_SERVICE_PATH = "_plugins/_security/saml/acs";
     protected final static Logger log = LogManager.getLogger(Saml2SettingsProvider.class);
 
     private final Settings opensearchSettings;
@@ -143,7 +145,7 @@ public class Saml2SettingsProvider {
     private void initSpEndpoints(HashMap<String, Object> configProperties) {
         configProperties.put(
             SettingsBuilder.SP_ASSERTION_CONSUMER_SERVICE_URL_PROPERTY_KEY,
-            this.buildAssertionConsumerEndpoint(this.opensearchSettings.get("kibana_url"))
+            Saml2SettingsProvider.buildAssertionConsumerEndpoint(this.opensearchSettings.get("kibana_url"))
         );
         configProperties.put(
             SettingsBuilder.SP_ASSERTION_CONSUMER_SERVICE_BINDING_PROPERTY_KEY,
@@ -216,13 +218,8 @@ public class Saml2SettingsProvider {
         return null;
     }
 
-    private String buildAssertionConsumerEndpoint(String dashboardsRoot) {
-
-        if (dashboardsRoot.endsWith("/")) {
-            return dashboardsRoot + "_opendistro/_security/saml/acs";
-        } else {
-            return dashboardsRoot + "/_opendistro/_security/saml/acs";
-        }
+    static String buildAssertionConsumerEndpoint(String dashboardsRoot) {
+        return dashboardsRoot + (dashboardsRoot.endsWith("/") ? "" : "/") + ASSERTION_CONSUMER_SERVICE_PATH;
     }
 
     static class SamlSettingsMap implements Map<String, Object> {

--- a/src/test/java/org/opensearch/security/auth/http/saml/Saml2SettingsProviderTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/saml/Saml2SettingsProviderTest.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.auth.http.saml;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class Saml2SettingsProviderTest {
+
+    @Test
+    public void buildsPluginsAssertionConsumerEndpoint() {
+        assertThat(
+            Saml2SettingsProvider.buildAssertionConsumerEndpoint("https://dashboards.example.com"),
+            is("https://dashboards.example.com/_plugins/_security/saml/acs")
+        );
+    }
+
+    @Test
+    public void avoidsDuplicatePathSeparator() {
+        assertThat(
+            Saml2SettingsProvider.buildAssertionConsumerEndpoint("https://dashboards.example.com/"),
+            is("https://dashboards.example.com/_plugins/_security/saml/acs")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Advertise `/_plugins/_security/saml/acs` as the assertion consumer service URL in SAML authentication requests.
- Keep URL construction correct whether `kibana_url` ends with `/` or not.
- Add focused coverage for both URL forms.

## Compatibility

This is paired with a Security Dashboards change that registers both the new `/_plugins` route and the legacy `/_opendistro` route. The new Dashboard routes are explicitly XSRF-exempt, so existing `server.xsrf.allowlist` entries using the legacy route can remain unchanged.

The Security Dashboards change must ship before this change so older Dashboard versions are not asked to handle an unknown route. Identity providers that restrict permitted ACS/reply URLs must allow `/_plugins/_security/saml/acs` before enabling this change. Keeping the legacy Dashboard route preserves IdP-initiated flows and configurations that still post directly to the old URL, but it cannot modify an IdP's own allowlist.

Companion Security Dashboards PR: https://github.com/opensearch-project/security-dashboards-plugin/pull/2519

## History

This revisits #1936 and #3246 without repeating the partial rollout from security-dashboards-plugin#895, which was reverted by security-dashboards-plugin#1035. It addresses #2060.

## Testing

- `./gradlew spotlessJavaCheck`
- Added `Saml2SettingsProviderTest`

The focused test is currently blocked locally before compilation by the existing `lucene-core` 10.5.0/10.5.1 snapshot dependency conflict on `main`.
