### PR TITLE
Fix Bouncy Castle 1.85.2 upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,17 +11,6 @@ updates:
     labels:
       - "dependabot"
       - "dependencies"
-  - package-ecosystem: "gradle"
-    directory: "/libs/opensaml/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      # For all packages, ignore all major versions to minimize breaking issues
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-major" ]
-    labels:
-      - "dependabot"
-      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -25,7 +25,7 @@ configurations.all {
     resolutionStrategy {
         force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
         force "org.bouncycastle:bcpkix-jdk18on:1.85"
-        force "org.bouncycastle:bcprov-jdk18on:1.85"
+        force "org.bouncycastle:bcprov-jdk18on:1.85.2"
         force "org.apache.commons:commons-lang3:${versions.commonslang}"
         force "tools.jackson.core:jackson-core:${versions.jackson3}"
     }


### PR DESCRIPTION
### Description

This replaces #6380 and #6382 with a compatible Bouncy Castle upgrade.

- Upgrade `bcprov-jdk18on` to the published `1.85.2` security patch.
- Keep `bcpkix-jdk18on` and its transitive `bcutil-jdk18on` dependency at `1.85`; version `1.85.2` is not published for those artifacts.
- Remove the redundant `/libs/opensaml/` Gradle Dependabot entry because the root Gradle updater already discovers this dependency and opened the duplicate PRs.

### Testing

- `./gradlew :libs:opensaml:dependencyInsight --dependency org.bouncycastle --configuration runtimeClasspath :libs:opensaml:shadowJar --console=plain`
- `./gradlew spotlessCheck --console=plain`
- `./gradlew buildHealth -Dmaven.repo.local=/private/tmp/security-empty-m2 --console=plain`
- Parsed `.github/dependabot.yml` with Ruby YAML