### PR TITLE
Allow standalone granular REST API permissions

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
@@ -39,7 +39,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.security.CrossClusterSearchTests.PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED;
 import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
-import static org.opensearch.security.api.InternalUsersRestApiIntegrationTest.REST_API_ADMIN_INTERNAL_USERS_ONLY;
 import static org.opensearch.security.dlic.rest.api.RestApiAuthorizationEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.dlic.rest.api.RestApiAuthorizationEvaluator.ENDPOINTS_WITH_PERMISSIONS;
 import static org.opensearch.security.dlic.rest.api.RestApiAuthorizationEvaluator.RELOAD_CERTS_ACTION;
@@ -107,12 +106,7 @@ public abstract class AbstractApiIntegrationTest {
         Map<String, Object> clusterSettings = new HashMap<>();
         clusterSettings.put(
             PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED,
-            List.of(
-                "user_admin__all_access",
-                REST_ADMIN_REST_API_ACCESS_ROLE.getName(),
-                "user_rest-api-admin__role",
-                REST_API_ADMIN_INTERNAL_USERS_ONLY
-            )
+            List.of("user_admin__all_access", REST_ADMIN_REST_API_ACCESS_ROLE.getName())
         );
         return clusterSettings;
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RestApiAuthorizationEvaluator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RestApiAuthorizationEvaluator.java
@@ -187,8 +187,10 @@ public class RestApiAuthorizationEvaluator {
 
     /**
      * Check if the current request is allowed to use the REST API and the
-     * requested end point. Using an admin certificate grants all permissions. A
-     * user/role can have restricted end points.
+     * requested end point. Access can be granted by a role in
+     * {@code plugins.security.restapi.roles_enabled}, by an explicit protected
+     * REST API permission when granular access is enabled, or by an admin
+     * certificate.
      *
      * @return an error message if user does not have access, null otherwise
      */
@@ -212,12 +214,50 @@ public class RestApiAuthorizationEvaluator {
             return null;
         }
 
+        if (hasGranularRestApiAccess(request, endpoint)) {
+            return null;
+        }
+
         final String certBasedAccessFailureReason = checkAdminCertBasedAccessPermissions(request);
         if (certBasedAccessFailureReason == null) {
             return null;
         }
 
         return constructAccessErrorMessage(roleBasedAccessFailureReason, certBasedAccessFailureReason);
+    }
+
+    private boolean hasGranularRestApiAccess(final RestRequest request, final Endpoint endpoint) {
+        if (restapiAdminEnabled == false || isGloballyDisabled(request, endpoint)) {
+            return false;
+        }
+
+        switch (endpoint) {
+            case SSL:
+                if (request.method() == Method.GET) {
+                    return isCurrentUserAdminFor(endpoint, CERTS_INFO_ACTION);
+                }
+                if (request.method() == Method.PUT) {
+                    return isCurrentUserAdminFor(endpoint, RELOAD_CERTS_ACTION);
+                }
+                return false;
+            case CONFIG:
+                if (request.method() == Method.GET || request.method() == Method.PUT || request.method() == Method.PATCH) {
+                    return isCurrentUserAdminFor(endpoint, SECURITY_CONFIG_UPDATE);
+                }
+                return false;
+            case RESOURCE_SHARING:
+                if (request.method() == Method.POST) {
+                    return isCurrentUserAdminFor(endpoint, RESOURCE_MIGRATE_ACTION);
+                }
+                return false;
+            default:
+                return isCurrentUserAdminFor(endpoint);
+        }
+    }
+
+    private boolean isGloballyDisabled(final RestRequest request, final Endpoint endpoint) {
+        final List<Method> disabledMethods = globallyDisabledEndpoints.get(endpoint);
+        return disabledMethods != null && disabledMethods.contains(request.method());
     }
 
     public boolean isCurrentUserAdminFor(final Endpoint endpoint, final String action) {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -253,7 +253,7 @@ public class NodesDnApiTest extends AbstractRestApiUnitTest {
             assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_OK));
 
             response = rh.executeGetRequest(ENDPOINT + "/actiongroups", restApiNodesDnHeader);
-            assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_OK));
+            assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
         }
         // rest api user
         {

--- a/src/test/resources/restapi/roles_mapping.yml
+++ b/src/test/resources/restapi/roles_mapping.yml
@@ -185,17 +185,6 @@ opendistro_security_test:
   hosts: []
   users:
   - "test"
-  - "rest_api_admin_user"
-  - "rest_api_admin_nodesdn"
-  - "rest_api_admin_allowlist"
-  - "rest_api_admin_roles"
-  - "rest_api_admin_rolesmapping"
-  - "rest_api_admin_actiongroups"
-  - "rest_api_admin_internalusers"
-  - "rest_api_admin_tenants"
-  - "rest_api_admin_ssl_info"
-  - "rest_api_admin_ssl_reloadcerts"
-  - "rest_api_admin_config_update"
   and_backend_roles: []
   description: "Migrated from v6"
 opendistro_security_role_starfleet_captains:


### PR DESCRIPTION
### Description

* Category: Bug fix
* Allows protected REST API permissions to authorize a request independently of `plugins.security.restapi.roles_enabled`.
* Previously, a non-admin user needed both a role in `plugins.security.restapi.roles_enabled` and the matching `restapi:admin/...` cluster permission. This made granular permissions additive only and meant they could not define a narrow REST API role.
* With this change, authorization has two independent paths:
  * A role in `plugins.security.restapi.roles_enabled` continues to grant broad REST API access, subject to configured endpoint restrictions.
  * When `plugins.security.restapi.admin.enabled` is `true`, a matching `restapi:admin/...` cluster permission grants the corresponding protected operation without requiring the role in `roles_enabled`.
* Global endpoint restrictions remain enforced, and admin TLS certificate behavior is unchanged.

This makes the permissions introduced by #2411 usable for least-privilege delegation while preserving the existing broad-access configuration.

Companion documentation PR: https://github.com/opensearch-project/documentation-website/pull/13063

### Issues Resolved

N/A

This is not a backport and does not introduce new permissions.

### Testing

* `./gradlew -I /tmp/job-scheduler-force-lucene.gradle test --tests org.opensearch.security.dlic.rest.api.RestApiAuthorizationEvaluatorTest`
* `./gradlew -I /tmp/job-scheduler-force-lucene.gradle test --tests org.opensearch.security.dlic.rest.api.NodesDnApiTest --tests org.opensearch.security.dlic.rest.api.AllowlistApiTest`
* `./gradlew -I /tmp/job-scheduler-force-lucene.gradle :integrationTest --tests org.opensearch.security.api.InternalUsersRestApiIntegrationTest --tests org.opensearch.security.api.ActionGroupsRestApiIntegrationTest`
* `./gradlew -I /tmp/job-scheduler-force-lucene.gradle spotlessJavaCheck`

The temporary Gradle init script only resolves version conflicts in the local 3.9.0-SNAPSHOT dependency graph by selecting Lucene Core 10.5.1 and OpenSearch Protobufs 1.7.0.

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR (N/A: no new roles or permissions)
- [x] API changes companion pull request created (N/A: no REST API shape change)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
