### PR TITLE
Reject reserved JWT subjects

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
@@ -24,9 +24,14 @@ import org.junit.Test;
 
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.auditlog.impl.AuditMessage;
+import org.opensearch.test.framework.AuditConfiguration;
+import org.opensearch.test.framework.AuditFilters;
 import org.opensearch.test.framework.JwtConfigBuilder;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.audit.AuditLogsRule;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
@@ -46,6 +51,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
+import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.security.Song.FIELD_TITLE;
 import static org.opensearch.security.Song.QUERY_TITLE_MAGNUM_OPUS;
 import static org.opensearch.security.Song.SONGS;
@@ -130,6 +136,7 @@ public class JwtAuthenticationTests {
         .nodeSettings(
             Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()))
         )
+        .audit(new AuditConfiguration(true).filters(new AuditFilters().enabledRest(true).enabledTransport(true)))
         .authc(AUTHC_HTTPBASIC_INTERNAL)
         .users(ADMIN_USER)
         .roles(DEPARTMENT_SONG_LISTENER_ROLE)
@@ -138,6 +145,9 @@ public class JwtAuthenticationTests {
 
     @Rule
     public LogsRule logsRule = new LogsRule("org.opensearch.security.auth.http.jwt.HTTPJwtAuthenticator");
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
 
     @BeforeClass
     public static void createTestData() {
@@ -218,6 +228,29 @@ public class JwtAuthenticationTests {
             response.assertStatusCode(401);
             logsRule.assertThatContainExactly("Invalid or expired JWT token.");
         }
+    }
+
+    @Test
+    public void shouldRejectReservedJwtSubjectAndAuditFailedLogin() {
+        Header header = tokenFactory1.generateValidToken("plugin:reserved-subject");
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            client.getAuthInfo().assertStatusCode(401);
+        }
+
+        logsRule.assertThatContainExactly("JWT subject uses a reserved security prefix");
+        auditLogsRule.assertExactlyOne((AuditMessage message) -> {
+            Map<String, Object> fields = message.getAsMap();
+            return message.getCategory() == AuditCategory.FAILED_LOGIN
+                && "<NONE>".equals(String.valueOf(fields.get(AuditMessage.REQUEST_EFFECTIVE_USER)))
+                && "REST".equals(String.valueOf(fields.get(AuditMessage.ORIGIN)))
+                && "REST".equals(String.valueOf(fields.get(AuditMessage.REQUEST_LAYER)))
+                && GET.name().equals(String.valueOf(fields.get(AuditMessage.REST_REQUEST_METHOD)))
+                && "/_opendistro/_security/authinfo".equals(String.valueOf(fields.get(AuditMessage.REST_REQUEST_PATH)))
+                && Boolean.FALSE.equals(fields.get(AuditMessage.IS_ADMIN_DN))
+                && !fields.containsKey(AuditMessage.REQUEST_INITIATING_USER)
+                && !fields.containsKey(AuditMessage.USER_ROLES)
+                && !fields.containsKey(AuditMessage.AUTH_METHOD);
+        });
     }
 
     @Test

--- a/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -41,6 +41,7 @@ import org.opensearch.security.auth.http.jwt.keybyoidc.KeyProvider;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityResponse;
 import org.opensearch.security.user.AuthCredentials;
+import org.opensearch.security.user.User;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -130,6 +131,10 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         final String subject = extractSubject(claimsSet);
         if (subject == null) {
             log.error("No subject found in JWT token");
+            return null;
+        }
+        if (User.hasReservedPrefix(subject)) {
+            log.warn("JWT subject uses a reserved security prefix");
             return null;
         }
 

--- a/src/main/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -40,6 +40,7 @@ import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityResponse;
 import org.opensearch.security.user.AuthCredentials;
+import org.opensearch.security.user.User;
 import org.opensearch.security.util.KeyUtils;
 
 import com.nimbusds.jwt.proc.BadJWTException;
@@ -171,6 +172,10 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
                 if (subject == null) {
                     log.error("No subject found in JWT token");
+                    return null;
+                }
+                if (User.hasReservedPrefix(subject)) {
+                    log.warn("JWT subject uses a reserved security prefix");
                     return null;
                 }
 

--- a/src/main/java/org/opensearch/security/identity/SecurePluginSubject.java
+++ b/src/main/java/org/opensearch/security/identity/SecurePluginSubject.java
@@ -22,19 +22,17 @@ import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 
 public class SecurePluginSubject implements PluginSubject {
-    private static final String PLUGIN_PRINCIPAL_PREFIX = "plugin:";
-
     private final ThreadPool threadPool;
     private final NamedPrincipal pluginPrincipal;
     private final User pluginUser;
 
     public static String getPluginPrincipalName(Plugin plugin) {
-        return PLUGIN_PRINCIPAL_PREFIX + plugin.getClass().getCanonicalName();
+        return User.PLUGIN_USER_PREFIX + plugin.getClass().getCanonicalName();
     }
 
     public static String getPluginClassNameFromPrincipal(String name) {
-        if (name.startsWith(PLUGIN_PRINCIPAL_PREFIX)) {
-            return name.substring(PLUGIN_PRINCIPAL_PREFIX.length());
+        if (name.startsWith(User.PLUGIN_USER_PREFIX)) {
+            return name.substring(User.PLUGIN_USER_PREFIX.length());
         }
         return null;
     }

--- a/src/main/java/org/opensearch/security/user/User.java
+++ b/src/main/java/org/opensearch/security/user/User.java
@@ -61,6 +61,7 @@ import org.opensearch.security.support.Base64Helper;
  */
 public class User implements Serializable, CustomAttributesAware, Principal, Subject {
 
+    public static final String PLUGIN_USER_PREFIX = "plugin:";
     public static final User ANONYMOUS = new User("opendistro_security_anonymous").withRoles("opendistro_security_anonymous_backendrole");
 
     // This is a default user that is injected into a transport request when a user info is not present and passive_intertransport_auth is
@@ -335,7 +336,7 @@ public class User implements Serializable, CustomAttributesAware, Principal, Sub
      * @return true if it has a plugin account attributes, otherwise false
      */
     public boolean isPluginUser() {
-        return name != null && name.startsWith("plugin:");
+        return name != null && name.startsWith(PLUGIN_USER_PREFIX);
     }
 
     /**
@@ -345,12 +346,18 @@ public class User implements Serializable, CustomAttributesAware, Principal, Sub
         return name != null && name.startsWith(org.opensearch.security.http.ApiTokenAuthenticator.API_TOKEN_USER_PREFIX);
     }
 
+    public static boolean hasReservedPrefix(String name) {
+        return name != null
+            && (name.startsWith(PLUGIN_USER_PREFIX)
+                || name.startsWith(org.opensearch.security.http.ApiTokenAuthenticator.API_TOKEN_USER_PREFIX));
+    }
+
     /**
      * If this user is a plugin user, returns the plugin Java class name. Otherwise, returns null.
      */
     public String getPluginName() {
         if (isPluginUser()) {
-            return name.substring("plugin:".length());
+            return name.substring(PLUGIN_USER_PREFIX.length());
         }
         return null;
     }

--- a/src/test/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -499,6 +499,36 @@ public class HTTPJwtAuthenticatorTest {
     }
 
     @Test
+    public void testPluginSubjectIsRejected() throws Exception {
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)),
+            Jwts.builder().setSubject("plugin:org.opensearch.example.Plugin")
+        );
+
+        Assert.assertNull(credentials);
+    }
+
+    @Test
+    public void testApiTokenSubjectIsRejected() throws Exception {
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)),
+            Jwts.builder().setSubject("token:administrative-token")
+        );
+
+        Assert.assertNull(credentials);
+    }
+
+    @Test
+    public void testReservedAlternativeSubjectIsRejected() throws Exception {
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("subject_key", "asub"),
+            Jwts.builder().setSubject("Leonard McCoy").claim("asub", "plugin:org.opensearch.example.Plugin")
+        );
+
+        Assert.assertNull(credentials);
+    }
+
+    @Test
     public void testNonStringAlternativeSubject() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -68,6 +68,20 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
+    public void reservedSubjectIsRejected() {
+        Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+        String token = TestJwts.createSigned(TestJwts.create("plugin:org.opensearch.example.Plugin", null, null), TestJwk.OCT_1);
+        HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(
+            new FakeRestRequest(ImmutableMap.of("Authorization", token), new HashMap<>()).asSecurityRequest(),
+            null
+        );
+
+        Assert.assertNull(creds);
+    }
+
+    @Test
     public void jwksUriTest() {
         Settings settings = Settings.builder()
             .put("jwks_uri", mockIdpServer.getJwksUri())


### PR DESCRIPTION
## Summary

- Reject JWT subjects beginning with the internal `plugin:` prefix.
- Also reject subjects beginning with the API-token `token:` prefix.
- Apply the check to both the legacy static-key and newer OIDC/JWKS authenticator paths.
- Centralize the plugin-user prefix in `User`.

## Testing

- `./gradlew test --tests org.opensearch.security.auth.http.jwt.HTTPJwtAuthenticatorTest --tests org.opensearch.security.auth.http.jwt.keybyoidc.HTTPJwtKeyByOpenIdConnectAuthenticatorTest`
- `./gradlew spotlessCheck`
- `./gradlew precommit` reaches the unchanged sample resource plugin and fails on existing `URL.openStream()` forbidden-API violations.
