### PR TITLE
Consume owned automatic merge actions

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -9,28 +9,38 @@ on:
     types: completed
 
 jobs:
-  automatic-merge-version-bumps:
+  find-triggering-pr:
+    if: github.repository == 'opensearch-project/security'
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      pr-number: ${{ steps.find-triggering-pr.outputs.pr-number }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-
-      - name: GitHub App token
-        id: github_app_token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - id: find-triggering-pr
-        uses: peternied/find-triggering-pr@ebe6a5ff5d5edfdf31b1f8aca20f89167c57bbef # v1
+        # TODO: Pin this to the upstream opensearch-build commit after opensearch-build#6463 merges.
+        uses: cwperks/opensearch-build/.github/actions/find-triggering-pr@542adc329a07cbba2597a705c10d3bcdf619df86
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
+          token: ${{ github.token }}
 
-      - uses: peternied/discerning-merger@07eafb14c195a2c23b291f6b008a686589cfb545 # v3
-        if: steps.find-triggering-pr.outputs.pr-number != null
+  automatic-merge-version-bumps:
+    needs: find-triggering-pr
+    if: needs.find-triggering-pr.outputs.pr-number != ''
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+    outputs:
+      merged: ${{ steps.merge.outputs.merged }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: merge
+        # TODO: Pin this to the upstream opensearch-build commit after opensearch-build#6463 merges.
+        uses: cwperks/opensearch-build/.github/actions/discerning-merger@542adc329a07cbba2597a705c10d3bcdf619df86
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
-          pull-request-number: ${{ steps.find-triggering-pr.outputs.pr-number }}
+          token: ${{ github.token }}
+          pull-request-number: ${{ needs.find-triggering-pr.outputs.pr-number }}
           allowed-authors: |
             dependabot[bot]
             opensearch-trigger-bot[bot]
@@ -38,3 +48,17 @@ jobs:
             build.gradle
             CHANGELOG.md
             .github/workflows/*.yml
+
+  run-post-merge-workflows:
+    needs: automatic-merge-version-bumps
+    if: needs.automatic-merge-version-bumps.outputs.merged == 'true'
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run post-merge workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run maven-publish.yml --ref main --repo ${{ github.repository }}
+          gh workflow run release-drafter.yml --ref main --repo ${{ github.repository }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,8 +1,13 @@
 name: Release-drafter
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
   update_release_draft:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,9 @@ Commit title ≤ 50 characters. Leave a blank line before the body; wrap body at
 
 - Always push to your personal fork. Never push directly to `opensearch-project/security` or to `main`.
 - Tests run automatically on all PRs across all supported JDK versions. All checks must pass before merging.
+- Automatic merges are limited to explicitly allowlisted bot authors and file patterns. The workflow uses
+  organization-owned actions with the repository `GITHUB_TOKEN`; successful automatic merges explicitly dispatch
+  workflows that have required post-merge side effects.
 
 ## Backports
 


### PR DESCRIPTION
### Description

Demonstrates how the Security plugin can consume the organization-owned
automatic-merge actions proposed in opensearch-project/opensearch-build#6463.

This is intentionally a Draft and is not ready to merge. The action references
temporarily point to the exact commit on `cwperks/opensearch-build`; they must be
replaced with an immutable upstream `opensearch-project/opensearch-build` commit
after the dependency merges.

### Changes

- Remove the retired `APP_ID` and `APP_PRIVATE_KEY` GitHub App token path from
  the automatic merge workflow.
- Use separate least-privilege repository `GITHUB_TOKEN` permissions for pull
  request discovery, merging, and workflow dispatch. No action that can merge a
  pull request receives `actions: write`.
- Consume the generic `find-triggering-pr` and `discerning-merger` actions.
- Run the automatic merge job only in `opensearch-project/security`.
- Explicitly dispatch Maven snapshot publication and release-draft maintenance
  after a successful automatic merge.
- Enable manual dispatch for the release-drafter workflow and grant it the
  permissions required with this repository's read-only default token.
- Document the automatic merge security model in `AGENTS.md`.

### Why explicit dispatch is required

Events created with `GITHUB_TOKEN` do not normally start another workflow.
`workflow_dispatch` is an exception, so the workflow explicitly dispatches the
post-merge jobs that produce or update artifacts. CI and link checking already
run against the pull request head and are not dispatched again in this draft.
Snapshot publication and release-draft maintenance were already triggered
automatically by the `push` event produced by the former GitHub App merge; the
explicit dispatch preserves those existing post-merge effects.

### Follow-ups and open questions

- Replace the temporary fork action references after opensearch-build#6463
  merges.
- Decide whether CI or link checking should also run against the resulting
  squash commit on `main`.
- Repair the separate Dependabot preparation workflow. Its current failed check
  will continue to prevent the discerning merger from merging a Dependabot PR.
- Perform an end-to-end automatic merge test after the upstream action is
  available and pinned.

Related: #6455

### Testing

- Parsed the changed workflow YAML successfully.
- Verified the diff with `git diff --check`.
- GitHub verified the commit's SSH signature and DCO sign-off.
